### PR TITLE
Replace mplfinance with matplotlib charts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = ">=3.12"
 authors         = [{ name = "narumi", email = "toucans-cutouts0f@icloud.com" }]
 dependencies    = [
   "loguru>=0.7.3",
+  "matplotlib>=3.9.0",
   "mcp[cli]>=1.26.0",
-  "mplfinance>=0.12.9",
   "yfinance>=1.2.0",
 ]
 

--- a/scripts/generate_sample_chart.py
+++ b/scripts/generate_sample_chart.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import base64
+from pathlib import Path
+from typing import cast
+
+import numpy as np
+import pandas as pd
+
+from yfmcp.chart import generate_chart
+from yfmcp.types import ChartType
+
+
+def _build_sample_price_data(days: int = 120) -> pd.DataFrame:
+    """Create deterministic OHLCV sample data for chart preview."""
+    rng = np.random.default_rng(7)
+    dates = pd.date_range("2025-01-01", periods=days, freq="D")
+
+    close = 120 + np.cumsum(rng.normal(loc=0.15, scale=1.8, size=days))
+    open_ = np.r_[close[0], close[:-1]] + rng.normal(loc=0.0, scale=0.8, size=days)
+    high = np.maximum(open_, close) + rng.uniform(0.4, 2.6, size=days)
+    low = np.minimum(open_, close) - rng.uniform(0.4, 2.6, size=days)
+    volume = rng.integers(900_000, 6_500_000, size=days)
+
+    return pd.DataFrame(
+        {
+            "Open": open_,
+            "High": high,
+            "Low": low,
+            "Close": close,
+            "Volume": volume,
+        },
+        index=dates,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a sample WebP chart using yfmcp chart renderer.")
+    parser.add_argument(
+        "--chart-type",
+        choices=["price_volume", "vwap", "volume_profile"],
+        default="price_volume",
+        help="Chart type to generate.",
+    )
+    parser.add_argument(
+        "--output",
+        default="sample-chart.webp",
+        help="Output file path (WebP).",
+    )
+    parser.add_argument(
+        "--symbol",
+        default="AAPL",
+        help="Symbol text shown in chart title.",
+    )
+    args = parser.parse_args()
+
+    df = _build_sample_price_data()
+    image = generate_chart(args.symbol, df, cast(ChartType, args.chart_type))
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(base64.b64decode(image.data))
+
+    print(f"Generated {args.chart_type} chart: {output_path.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/yfmcp/chart.py
+++ b/src/yfmcp/chart.py
@@ -1,6 +1,13 @@
 import base64
 import io
 
+import matplotlib
+
+matplotlib.use("Agg")  # Use non-interactive backend (must be set before pyplot is imported)
+
+import matplotlib.cm as cm
+import matplotlib.gridspec as gridspec
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from mcp.types import ImageContent
@@ -119,14 +126,6 @@ def generate_chart(symbol: str, df: pd.DataFrame, chart_type: ChartType) -> Imag
     Shows candlestick price data with volume, optionally with VWAP or volume profile.
     Returns base64-encoded WebP image for efficient token usage.
     """
-
-    import matplotlib
-
-    matplotlib.use("Agg")  # Use non-interactive backend
-
-    import matplotlib.cm as cm
-    import matplotlib.gridspec as gridspec
-    import matplotlib.pyplot as plt
 
     # Ensure required OHLCV columns exist and preserve order.
     df = df[["Open", "High", "Low", "Close", "Volume"]]

--- a/src/yfmcp/chart.py
+++ b/src/yfmcp/chart.py
@@ -23,6 +23,11 @@ VOLUME_PROFILE_MARGINS = {  # Figure margins
 }
 VWAP_LINE_WIDTH = 2  # VWAP line thickness in points
 VOLUME_PROFILE_ALPHA = 0.7  # Transparency for volume profile bars (0=transparent, 1=opaque)
+UP_CANDLE_COLOR = "#2ca02c"
+DOWN_CANDLE_COLOR = "#d62728"
+CANDLE_WIDTH = 0.6
+VOLUME_ALPHA = 0.8
+MAX_X_TICKS = 8
 
 
 def _calculate_volume_profile(df: pd.DataFrame, bins: int = DEFAULT_VOLUME_PROFILE_BINS) -> pd.Series:
@@ -58,8 +63,58 @@ def _calculate_volume_profile(df: pd.DataFrame, bins: int = DEFAULT_VOLUME_PROFI
     return volume_profile
 
 
+def _compute_x_ticks(index: pd.Index, max_ticks: int = MAX_X_TICKS) -> tuple[np.ndarray, list[str]]:
+    """Return evenly distributed tick positions and labels for chart x-axis."""
+    total = len(index)
+    if total == 0:
+        return np.array([], dtype=int), []
+
+    tick_count = min(max_ticks, total)
+    positions = np.linspace(0, total - 1, tick_count, dtype=int)
+    positions = np.unique(positions)
+
+    if isinstance(index, pd.DatetimeIndex):
+        labels = index[positions].strftime("%Y-%m-%d").tolist()
+    else:
+        labels = [str(index[pos]) for pos in positions]
+
+    return positions, labels
+
+
+def _plot_candlesticks(ax, df: pd.DataFrame, x: np.ndarray) -> np.ndarray:
+    """Plot candlesticks on target axes and return per-bar colors."""
+    opens = df["Open"].to_numpy(dtype=float)
+    highs = df["High"].to_numpy(dtype=float)
+    lows = df["Low"].to_numpy(dtype=float)
+    closes = df["Close"].to_numpy(dtype=float)
+
+    is_up = closes >= opens
+    colors = np.where(is_up, UP_CANDLE_COLOR, DOWN_CANDLE_COLOR)
+
+    ax.vlines(x, lows, highs, color=colors, linewidth=1.0, zorder=1)
+
+    body_bottom = np.minimum(opens, closes)
+    body_height = np.abs(closes - opens)
+    # Keep near-flat candles visible.
+    min_body_height = max((highs.max() - lows.min()) * 1e-4, 1e-6)
+    body_height = np.maximum(body_height, min_body_height)
+
+    ax.bar(
+        x,
+        body_height,
+        width=CANDLE_WIDTH,
+        bottom=body_bottom,
+        color=colors,
+        edgecolor=colors,
+        linewidth=0.8,
+        zorder=2,
+    )
+
+    return colors
+
+
 def generate_chart(symbol: str, df: pd.DataFrame, chart_type: ChartType) -> ImageContent | str:
-    """Generate a financial chart using mplfinance.
+    """Generate a financial chart using matplotlib.
 
     Shows candlestick price data with volume, optionally with VWAP or volume profile.
     Returns base64-encoded WebP image for efficient token usage.
@@ -70,12 +125,13 @@ def generate_chart(symbol: str, df: pd.DataFrame, chart_type: ChartType) -> Imag
     matplotlib.use("Agg")  # Use non-interactive backend
 
     import matplotlib.cm as cm
+    import matplotlib.gridspec as gridspec
     import matplotlib.pyplot as plt
-    import mplfinance as mpf
 
-    # Prepare data for mplfinance (needs OHLCV columns)
-    # Ensure column names match what mplfinance expects
+    # Ensure required OHLCV columns exist and preserve order.
     df = df[["Open", "High", "Low", "Close", "Volume"]]
+    x = np.arange(len(df))
+    tick_positions, tick_labels = _compute_x_ticks(df.index)
 
     # Handle volume profile separately as it needs custom layout
     if chart_type == "volume_profile":
@@ -86,9 +142,10 @@ def generate_chart(symbol: str, df: pd.DataFrame, chart_type: ChartType) -> Imag
         fig = plt.figure(figsize=DEFAULT_CHART_FIGSIZE)
 
         # Create gridspec for layout: left side for candlestick+volume, right side for volume profile
-        gs = fig.add_gridspec(
+        gs = gridspec.GridSpec(
             2,
             2,
+            figure=fig,
             width_ratios=VOLUME_PROFILE_WIDTH_RATIOS,
             height_ratios=VOLUME_PROFILE_HEIGHT_RATIOS,
             hspace=VOLUME_PROFILE_HSPACE,
@@ -103,17 +160,11 @@ def generate_chart(symbol: str, df: pd.DataFrame, chart_type: ChartType) -> Imag
         # Right side: volume profile (aligned with price chart)
         ax_profile = fig.add_subplot(gs[0, 1], sharey=ax_price)
 
-        # Plot candlestick and volume using mplfinance on our custom axes
-        style = mpf.make_mpf_style(base_mpf_style="yahoo", rc={"figure.facecolor": "white"})
-        mpf.plot(
-            df,
-            type="candle",
-            volume=ax_volume,
-            style=style,
-            ax=ax_price,
-            show_nontrading=False,
-            returnfig=False,
-        )
+        # Plot candlestick and matching volume bars
+        candle_colors = _plot_candlesticks(ax_price, df, x)
+        ax_volume.bar(x, df["Volume"], width=CANDLE_WIDTH, color=candle_colors, alpha=VOLUME_ALPHA)
+        ax_volume.set_ylabel("Volume")
+        ax_volume.grid(True, alpha=0.3, axis="y")
 
         # Plot volume profile as horizontal bars on the right
         viridis = cm.get_cmap("viridis")
@@ -126,6 +177,13 @@ def generate_chart(symbol: str, df: pd.DataFrame, chart_type: ChartType) -> Imag
 
         # Set overall title
         fig.suptitle(f"{symbol} - Volume Profile", fontsize=16, fontweight="bold", y=0.98)
+        ax_price.set_ylabel("Price")
+        ax_price.grid(True, alpha=0.3)
+        ax_price.set_xlim(-0.5, len(df) - 0.5)
+        if len(tick_positions) > 0:
+            ax_volume.set_xticks(tick_positions)
+            ax_volume.set_xticklabels(tick_labels, rotation=45, ha="right")
+        plt.setp(ax_price.get_xticklabels(), visible=False)
 
         # Save directly to WebP format
         buf = io.BytesIO()
@@ -134,35 +192,45 @@ def generate_chart(symbol: str, df: pd.DataFrame, chart_type: ChartType) -> Imag
         plt.close(fig)
 
     else:
-        # Standard mplfinance chart (price_volume or vwap)
-        addplots = []
+        # Standard chart (price_volume or vwap)
+        fig, (ax_price, ax_volume) = plt.subplots(
+            2,
+            1,
+            figsize=DEFAULT_CHART_FIGSIZE,
+            sharex=True,
+            gridspec_kw={"height_ratios": VOLUME_PROFILE_HEIGHT_RATIOS, "hspace": 0.05},
+        )
+        fig.subplots_adjust(**VOLUME_PROFILE_MARGINS)
+
+        candle_colors = _plot_candlesticks(ax_price, df, x)
+        ax_volume.bar(x, df["Volume"], width=CANDLE_WIDTH, color=candle_colors, alpha=VOLUME_ALPHA)
+        ax_volume.set_ylabel("Volume")
+        ax_volume.grid(True, alpha=0.3, axis="y")
+        ax_price.set_ylabel("Price")
+        ax_price.grid(True, alpha=0.3)
+
         if chart_type == "vwap":
             # VWAP = Sum(Price * Volume) / Sum(Volume)
             typical_price = (df["High"] + df["Low"] + df["Close"]) / 3
-            vwap = (typical_price * df["Volume"]).cumsum() / df["Volume"].cumsum()
-            addplots.append(mpf.make_addplot(vwap, color="orange", width=VWAP_LINE_WIDTH, linestyle="--", label="VWAP"))
+            cumulative_volume = df["Volume"].cumsum().replace(0, np.nan)
+            vwap = (typical_price * df["Volume"]).cumsum() / cumulative_volume
+            ax_price.plot(
+                x, vwap.to_numpy(dtype=float), color="orange", linewidth=VWAP_LINE_WIDTH, linestyle="--", label="VWAP"
+            )
+            ax_price.legend(loc="upper left")
 
-        # Create style
-        style = mpf.make_mpf_style(base_mpf_style="yahoo", rc={"figure.facecolor": "white"})
+        ax_price.set_title(f"{symbol} - {chart_type.replace('_', ' ').title()}")
+        ax_price.set_xlim(-0.5, len(df) - 0.5)
+        if len(tick_positions) > 0:
+            ax_volume.set_xticks(tick_positions)
+            ax_volume.set_xticklabels(tick_labels, rotation=45, ha="right")
+        plt.setp(ax_price.get_xticklabels(), visible=False)
 
         # Save chart directly to WebP format
         buf = io.BytesIO()
-        plot_kwargs = {
-            "type": "candle",
-            "volume": True,
-            "style": style,
-            "title": f"{symbol} - {chart_type.replace('_', ' ').title()}",
-            "ylabel": "Price",
-            "ylabel_lower": "Volume",
-            "savefig": {"fname": buf, "format": "webp", "dpi": DEFAULT_CHART_DPI, "bbox_inches": "tight"},
-            "show_nontrading": False,
-            "returnfig": False,
-        }
-        if addplots:
-            plot_kwargs["addplot"] = addplots
-
-        mpf.plot(df, **plot_kwargs)
+        fig.savefig(buf, format="webp", dpi=DEFAULT_CHART_DPI, bbox_inches="tight")
         buf.seek(0)
+        plt.close(fig)
 
     return ImageContent(
         type="image",

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -1,8 +1,6 @@
 """Unit tests for chart generation functions."""
 
 import base64
-from unittest.mock import MagicMock
-from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -58,22 +56,8 @@ def test_calculate_volume_profile_default_bins(sample_price_data: pd.DataFrame) 
     assert len(volume_profile) == DEFAULT_VOLUME_PROFILE_BINS
 
 
-@patch("matplotlib.pyplot.figure")
-def test_generate_chart_volume_profile(
-    mock_figure: MagicMock,
-    sample_price_data: pd.DataFrame,
-) -> None:
+def test_generate_chart_volume_profile(sample_price_data: pd.DataFrame) -> None:
     """Test volume profile chart generation."""
-    # Mock figure and its methods
-    mock_fig = MagicMock()
-    mock_figure.return_value = mock_fig
-    mock_gs = MagicMock()
-    mock_fig.add_gridspec.return_value = mock_gs
-    mock_fig.suptitle.return_value = None
-
-    # Mock savefig to avoid actual file I/O
-    mock_fig.savefig = MagicMock()
-
     result = generate_chart("AAPL", sample_price_data, "volume_profile")
 
     # Check that result is ImageContent
@@ -81,13 +65,11 @@ def test_generate_chart_volume_profile(
     assert result.type == "image"
     assert hasattr(result, "mimeType")
     assert result.mimeType == "image/webp"
-    assert hasattr(result, "data")
 
-    # Verify the figure was created with correct size
-    mock_figure.assert_called_once()
-
-    # Verify savefig was called with correct DPI
-    assert mock_fig.savefig.called
+    # Validate that a real WebP image was produced
+    raw = base64.b64decode(result.data)
+    assert len(raw) > 0
+    assert raw[:4] == b"RIFF" and raw[8:12] == b"WEBP"
 
 
 def test_generate_chart_price_volume(sample_price_data: pd.DataFrame) -> None:

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -1,5 +1,6 @@
 """Unit tests for chart generation functions."""
 
+import base64
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -57,11 +58,9 @@ def test_calculate_volume_profile_default_bins(sample_price_data: pd.DataFrame) 
     assert len(volume_profile) == DEFAULT_VOLUME_PROFILE_BINS
 
 
-@patch("mplfinance.plot")
 @patch("matplotlib.pyplot.figure")
 def test_generate_chart_volume_profile(
     mock_figure: MagicMock,
-    mock_mpf_plot: MagicMock,
     sample_price_data: pd.DataFrame,
 ) -> None:
     """Test volume profile chart generation."""
@@ -91,11 +90,7 @@ def test_generate_chart_volume_profile(
     assert mock_fig.savefig.called
 
 
-@patch("mplfinance.plot")
-def test_generate_chart_price_volume(
-    mock_mpf_plot: MagicMock,
-    sample_price_data: pd.DataFrame,
-) -> None:
+def test_generate_chart_price_volume(sample_price_data: pd.DataFrame) -> None:
     """Test price_volume chart generation."""
     result = generate_chart("AAPL", sample_price_data, "price_volume")
 
@@ -104,25 +99,21 @@ def test_generate_chart_price_volume(
     assert result.type == "image"
     assert hasattr(result, "mimeType")
     assert result.mimeType == "image/webp"
+    assert isinstance(result.data, str)
+    assert len(result.data) > 0
+    assert len(base64.b64decode(result.data)) > 0
 
-    # Verify mpf.plot was called
-    assert mock_mpf_plot.called
 
-
-@patch("mplfinance.plot")
-def test_generate_chart_vwap(
-    mock_mpf_plot: MagicMock,
-    sample_price_data: pd.DataFrame,
-) -> None:
+def test_generate_chart_vwap(sample_price_data: pd.DataFrame) -> None:
     """Test VWAP chart generation."""
     result = generate_chart("AAPL", sample_price_data, "vwap")
 
     # Check that result is ImageContent
     assert hasattr(result, "type")
     assert result.type == "image"
-
-    # Verify mpf.plot was called
-    assert mock_mpf_plot.called
+    assert isinstance(result.data, str)
+    assert len(result.data) > 0
+    assert len(base64.b64decode(result.data)) > 0
 
 
 def test_chart_constants() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -776,19 +776,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mplfinance"
-version = "0.12.10b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "matplotlib" },
-    { name = "pandas" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/a9/34e7998d02fb58fae04f750444ce4e95e75f3a08dad17fb2d32098a97834/mplfinance-0.12.10b0.tar.gz", hash = "sha256:7da150b5851aa5119ad6e06b55e48338b619bb6773f1b85df5de67a5ffd917bf", size = 70117, upload-time = "2023-08-02T15:13:53.829Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/d9/31c436ea7673c21a5bf3fc747bc7f63377582dfe845c3004d3e46f9deee0/mplfinance-0.12.10b0-py3-none-any.whl", hash = "sha256:76d3b095f05ff35de730751649de063bea4064d0c49b21b6182c82997a7f52bb", size = 75016, upload-time = "2023-08-02T15:13:52.022Z" },
-]
-
-[[package]]
 name = "multitasking"
 version = "0.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1641,8 +1628,8 @@ version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },
+    { name = "matplotlib" },
     { name = "mcp", extra = ["cli"] },
-    { name = "mplfinance" },
     { name = "yfinance" },
 ]
 
@@ -1658,8 +1645,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "matplotlib", specifier = ">=3.9.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
-    { name = "mplfinance", specifier = ">=0.12.9" },
     { name = "yfinance", specifier = ">=1.2.0" },
 ]
 


### PR DESCRIPTION
## Motivation
- remove the `mplfinance` dependency and keep chart rendering within `matplotlib` only
- keep chart output behavior aligned with existing MCP tool responses (WebP image payload)

## Changes
- replace `mplfinance`-based chart rendering with pure `matplotlib` implementation in `src/yfmcp/chart.py`
- keep support for `price_volume`, `vwap`, and `volume_profile` chart types
- update chart tests to validate generated WebP payloads without `mplfinance` mocks
- update dependencies in `pyproject.toml` and `uv.lock`
- add `scripts/generate_sample_chart.py` for local chart preview generation

## Validation
- `uv run pytest -v -s tests/test_chart.py`
- `prek run -a`