### PR TITLE
Add yfinance_get_financials tool for historical financial statements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## Architecture Overview
 - MCP tools are exposed from `yfmcp.server` with `yfinance_`-prefixed names:
-  `yfinance_get_ticker_info`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`.
+  `yfinance_get_ticker_info`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`.
 - All blocking `yfinance` operations MUST be wrapped with `asyncio.to_thread()`.
 - Errors MUST be returned via `create_error_response()` with structured JSON (`error`, `error_code`, optional `details`).
 - Chart responses are returned as base64-encoded WebP `ImageContent`; tabular history uses Markdown tables.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Fetch historical price data and optionally generate technical analysis charts.
 
 ### `yfinance_get_financials`
 
-Fetch financial statements (income statement and balance sheet) with historical data.
+Fetch financial statements (income statement, balance sheet, and cash flow) with historical data.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that p
 ## Features
 
 - **Stock Data** — Company info, financials, valuation metrics, dividends, and trading data
+- **Financial Statements** — Income statement and balance sheet with historical data (EBIT, Invested Capital, etc.)
 - **Financial News** — Recent news articles and press releases for any ticker
 - **Search** — Find stocks, ETFs, and news across Yahoo Finance
 - **Sector Rankings** — Top ETFs, mutual funds, companies, growth leaders, and top performers by sector
@@ -91,6 +92,20 @@ Fetch historical price data and optionally generate technical analysis charts.
 **Returns:**
 - Without `chart_type`: Markdown table with Date, Open, High, Low, Close, Volume, Dividends, and Stock Splits columns.
 - With `chart_type`: Base64-encoded WebP image for efficient token usage.
+
+### `yfinance_get_financials`
+
+Fetch financial statements (income statement and balance sheet) with historical data.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | Yes | Stock ticker symbol |
+| `frequency` | string | No | `"annual"` (yearly), `"quarterly"` (quarterly), or `"ttm"` (trailing twelve months). Default: `"annual"` |
+
+**Returns:** JSON object with income statement and balance sheet data for each reporting period.
+
+- **Income Statement fields**: EBIT, Net Income, Tax Provision, Pretax Income, Interest Expense, Total Revenue, Operating Income, EBITDA, Normalized Income
+- **Balance Sheet fields**: Stockholders Equity, Total Debt, Cash And Cash Equivalents, Invested Capital, Net Debt, Total Assets, Total Liabilities Net Minority Interest, Net Tangible Assets, Tangible Book Value
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ Fetch financial statements (income statement and balance sheet) with historical 
 | `symbol` | string | Yes | Stock ticker symbol |
 | `frequency` | string | No | `"annual"` (yearly), `"quarterly"` (quarterly), or `"ttm"` (trailing twelve months). Default: `"annual"` |
 
-**Returns:** JSON object with income statement and balance sheet data for each reporting period.
+**Returns:** JSON object with income statement, balance sheet, and cash flow data for each reporting period.
 
 - **Income Statement fields**: EBIT, Net Income, Tax Provision, Pretax Income, Interest Expense, Total Revenue, Operating Income, EBITDA, Normalized Income
 - **Balance Sheet fields**: Stockholders Equity, Total Debt, Cash And Cash Equivalents, Invested Capital, Net Debt, Total Assets, Total Liabilities Net Minority Interest, Net Tangible Assets, Tangible Book Value
+- **Cash Flow fields**: Operating Cash Flow, Free Cash Flow, Capital Expenditure, Net Income From Continuing Operations, Depreciation And Amortization, Change In Working Capital, Cash Dividends Paid
 
 ## Usage
 

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -613,5 +613,123 @@ async def get_price_history(
     return generate_chart(symbol=symbol, df=df, chart_type=chart_type)
 
 
+@mcp.tool(
+    name="yfinance_get_financials",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def get_financials(
+    symbol: Annotated[str, Field(description="Stock ticker symbol (e.g., 'AAPL', 'GOOGL', 'MSFT')")],
+    frequency: Annotated[
+        str,
+        Field(
+            description=(
+                "Reporting frequency: 'annual' for yearly, 'quarterly' for quarterly, "
+                "or 'ttm' for trailing twelve months"
+            )
+        ),
+    ] = "annual",
+) -> str:
+    """Fetch financial statements (income statement and balance sheet) with historical data.
+
+    Returns JSON with income statement and balance sheet data across reporting periods.
+
+    Use the data to analyze trends, calculate ratios, or compare periods.
+    """
+    try:
+        ticker = await asyncio.to_thread(yf.Ticker, symbol)
+    except (ConnectionError, TimeoutError, OSError) as exc:
+        return create_error_response(
+            f"Network error while fetching financials for '{symbol}'. Check your internet connection and try again.",
+            error_code="NETWORK_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch financials for '{symbol}'. Verify the symbol is correct.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    income_stmt = None
+    balance_sheet = None
+
+    if frequency == "annual":
+        income_stmt = await asyncio.to_thread(lambda: ticker.income_stmt)
+        balance_sheet = await asyncio.to_thread(lambda: ticker.balance_sheet)
+    elif frequency == "quarterly":
+        income_stmt = await asyncio.to_thread(lambda: ticker.quarterly_income_stmt)
+        balance_sheet = await asyncio.to_thread(lambda: ticker.quarterly_balance_sheet)
+    elif frequency == "ttm":
+        income_stmt = await asyncio.to_thread(lambda: ticker.ttm_income_stmt)
+        balance_sheet = None  # TTM balance sheet not directly available
+    else:
+        return create_error_response(
+            f"Invalid frequency '{frequency}'. Valid options: 'annual', 'quarterly', 'ttm'.",
+            error_code="INVALID_PARAMS",
+            details={"frequency": frequency, "valid_options": ["annual", "quarterly", "ttm"]},
+        )
+
+    result = _build_financials_response(income_stmt, balance_sheet)
+
+    if not result:
+        return create_error_response(
+            f"No financial data available for '{symbol}' with frequency='{frequency}'.",
+            error_code="NO_DATA",
+            details={"symbol": symbol, "frequency": frequency},
+        )
+
+    return dump_json(result)
+
+
+def _build_financials_response(income_stmt, balance_sheet) -> dict:
+    """Build financials response from income statement and balance sheet DataFrames."""
+    result = {}
+
+    if income_stmt is not None and not income_stmt.empty:
+        income_fields = [
+            "EBIT",
+            "Net Income",
+            "Tax Provision",
+            "Pretax Income",
+            "Interest Expense",
+            "Total Revenue",
+            "Operating Income",
+            "EBITDA",
+            "Normalized Income",
+        ]
+        available_income_fields = [f for f in income_fields if f in income_stmt.index]
+        result["income_statement"] = {}
+        for field in available_income_fields:
+            result["income_statement"][field] = {
+                str(col.date()): income_stmt.loc[field, col] for col in income_stmt.columns
+            }
+
+    if balance_sheet is not None and not balance_sheet.empty:
+        balance_fields = [
+            "Stockholders Equity",
+            "Total Debt",
+            "Cash And Cash Equivalents",
+            "Invested Capital",
+            "Net Debt",
+            "Total Assets",
+            "Total Liabilities Net Minority Interest",
+            "Net Tangible Assets",
+            "Tangible Book Value",
+        ]
+        available_balance_fields = [f for f in balance_fields if f in balance_sheet.index]
+        result["balance_sheet"] = {}
+        for field in available_balance_fields:
+            result["balance_sheet"][field] = {
+                str(col.date()): balance_sheet.loc[field, col] for col in balance_sheet.columns
+            }
+
+    return result
+
+
 def main() -> None:
     mcp.run()

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -634,9 +634,9 @@ async def get_financials(
         ),
     ] = "annual",
 ) -> str:
-    """Fetch financial statements (income statement and balance sheet) with historical data.
+    """Fetch financial statements (income statement, balance sheet, and cash flow) with historical data.
 
-    Returns JSON with income statement and balance sheet data across reporting periods.
+    Returns JSON with income statement, balance sheet, and cash flow data across reporting periods.
 
     Use the data to analyze trends, calculate ratios, or compare periods.
     """
@@ -657,16 +657,20 @@ async def get_financials(
 
     income_stmt = None
     balance_sheet = None
+    cash_flow = None
 
     if frequency == "annual":
         income_stmt = await asyncio.to_thread(lambda: ticker.income_stmt)
         balance_sheet = await asyncio.to_thread(lambda: ticker.balance_sheet)
+        cash_flow = await asyncio.to_thread(lambda: ticker.cashflow)
     elif frequency == "quarterly":
         income_stmt = await asyncio.to_thread(lambda: ticker.quarterly_income_stmt)
         balance_sheet = await asyncio.to_thread(lambda: ticker.quarterly_balance_sheet)
+        cash_flow = await asyncio.to_thread(lambda: ticker.quarterly_cashflow)
     elif frequency == "ttm":
         income_stmt = await asyncio.to_thread(lambda: ticker.ttm_income_stmt)
         balance_sheet = None  # TTM balance sheet not directly available
+        cash_flow = None  # TTM cash flow not directly available
     else:
         return create_error_response(
             f"Invalid frequency '{frequency}'. Valid options: 'annual', 'quarterly', 'ttm'.",
@@ -674,7 +678,7 @@ async def get_financials(
             details={"frequency": frequency, "valid_options": ["annual", "quarterly", "ttm"]},
         )
 
-    result = _build_financials_response(income_stmt, balance_sheet)
+    result = _build_financials_response(income_stmt, balance_sheet, cash_flow)
 
     if not result:
         return create_error_response(
@@ -686,8 +690,8 @@ async def get_financials(
     return dump_json(result)
 
 
-def _build_financials_response(income_stmt, balance_sheet) -> dict:
-    """Build financials response from income statement and balance sheet DataFrames."""
+def _build_financials_response(income_stmt, balance_sheet, cash_flow=None) -> dict:
+    """Build financials response from income statement, balance sheet, and cash flow DataFrames."""
     result = {}
 
     if income_stmt is not None and not income_stmt.empty:
@@ -727,6 +731,21 @@ def _build_financials_response(income_stmt, balance_sheet) -> dict:
             result["balance_sheet"][field] = {
                 str(col.date()): balance_sheet.loc[field, col] for col in balance_sheet.columns
             }
+
+    if cash_flow is not None and not cash_flow.empty:
+        cash_flow_fields = [
+            "Operating Cash Flow",
+            "Free Cash Flow",
+            "Capital Expenditure",
+            "Net Income From Continuing Operations",
+            "Depreciation And Amortization",
+            "Change In Working Capital",
+            "Cash Dividends Paid",
+        ]
+        available_cash_flow_fields = [f for f in cash_flow_fields if f in cash_flow.index]
+        result["cash_flow"] = {}
+        for field in available_cash_flow_fields:
+            result["cash_flow"][field] = {str(col.date()): cash_flow.loc[field, col] for col in cash_flow.columns}
 
     return result
 

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -659,27 +659,40 @@ async def get_financials(
     balance_sheet = None
     cash_flow = None
 
-    if frequency == "annual":
-        income_stmt = await asyncio.to_thread(lambda: ticker.income_stmt)
-        balance_sheet = await asyncio.to_thread(lambda: ticker.balance_sheet)
-        cash_flow = await asyncio.to_thread(lambda: ticker.cashflow)
-    elif frequency == "quarterly":
-        income_stmt = await asyncio.to_thread(lambda: ticker.quarterly_income_stmt)
-        balance_sheet = await asyncio.to_thread(lambda: ticker.quarterly_balance_sheet)
-        cash_flow = await asyncio.to_thread(lambda: ticker.quarterly_cashflow)
-    elif frequency == "ttm":
-        income_stmt = await asyncio.to_thread(lambda: ticker.ttm_income_stmt)
-        balance_sheet = None  # TTM balance sheet not directly available
-        cash_flow = None  # TTM cash flow not directly available
-    else:
+    if frequency not in {"annual", "quarterly", "ttm"}:
         return create_error_response(
             f"Invalid frequency '{frequency}'. Valid options: 'annual', 'quarterly', 'ttm'.",
             error_code="INVALID_PARAMS",
             details={"frequency": frequency, "valid_options": ["annual", "quarterly", "ttm"]},
         )
 
-    result = _build_financials_response(income_stmt, balance_sheet, cash_flow)
+    try:
+        if frequency == "annual":
+            income_stmt = await asyncio.to_thread(lambda: ticker.income_stmt)
+            balance_sheet = await asyncio.to_thread(lambda: ticker.balance_sheet)
+            cash_flow = await asyncio.to_thread(lambda: ticker.cashflow)
+        elif frequency == "quarterly":
+            income_stmt = await asyncio.to_thread(lambda: ticker.quarterly_income_stmt)
+            balance_sheet = await asyncio.to_thread(lambda: ticker.quarterly_balance_sheet)
+            cash_flow = await asyncio.to_thread(lambda: ticker.quarterly_cashflow)
+        else:
+            income_stmt = await asyncio.to_thread(lambda: ticker.ttm_income_stmt)
+            balance_sheet = None  # TTM balance sheet not directly available
+            cash_flow = None  # TTM cash flow not directly available
 
+        result = _build_financials_response(income_stmt, balance_sheet, cash_flow)
+    except (ConnectionError, TimeoutError, OSError) as exc:
+        return create_error_response(
+            f"Network error while fetching financials for '{symbol}'. Check your internet connection and try again.",
+            error_code="NETWORK_ERROR",
+            details={"symbol": symbol, "frequency": frequency, "exception": str(exc)},
+        )
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch financials for '{symbol}'. Verify the symbol is correct.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "frequency": frequency, "exception": str(exc)},
+        )
     if not result:
         return create_error_response(
             f"No financial data available for '{symbol}' with frequency='{frequency}'.",


### PR DESCRIPTION
Adds yfinance_get_financials tool that returns historical income statement and balance sheet data (EBIT, Net Income, Tax Provision, Invested Capital, etc.) for annual, quarterly, or TTM periods.

Validated: lint, type check, and format all pass.