### PR TITLE
[codex] Add financials unit tests

### DIFF
--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -8,11 +8,215 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
+from yfmcp.server import _build_financials_response
+from yfmcp.server import get_financials
 from yfmcp.server import get_top_companies
 from yfmcp.server import get_top_etfs
 from yfmcp.server import get_top_growth_companies
 from yfmcp.server import get_top_mutual_funds
 from yfmcp.server import get_top_performing_companies
+
+
+def _financials_df(rows: dict[str, list[int]]) -> pd.DataFrame:
+    """Build a yfinance-shaped financial statement DataFrame."""
+    return pd.DataFrame(
+        rows,
+        index=[pd.Timestamp("2024-12-31"), pd.Timestamp("2023-12-31")],
+        dtype=object,
+    ).T
+
+
+async def _run_to_thread(func, *args, **kwargs):
+    if callable(func):
+        return func(*args, **kwargs)
+    return func
+
+
+class _FinancialsReadErrorTicker:
+    @property
+    def income_stmt(self):
+        raise RuntimeError("statement read failed")
+
+
+def test_build_financials_response_with_all_sections() -> None:
+    """Test building a financials response with all supported statement sections."""
+    income_stmt = _financials_df(
+        {
+            "Total Revenue": [1000, 900],
+            "Net Income": [120, 100],
+            "Unsupported Income Row": [1, 2],
+        }
+    )
+    balance_sheet = _financials_df(
+        {
+            "Total Assets": [5000, 4500],
+            "Total Debt": [800, 750],
+            "Unsupported Balance Row": [3, 4],
+        }
+    )
+    cash_flow = _financials_df(
+        {
+            "Operating Cash Flow": [300, 280],
+            "Free Cash Flow": [200, 180],
+            "Unsupported Cash Flow Row": [5, 6],
+        }
+    )
+
+    result = _build_financials_response(income_stmt, balance_sheet, cash_flow)
+
+    assert set(result) == {"income_statement", "balance_sheet", "cash_flow"}
+    assert result["income_statement"]["Total Revenue"]["2024-12-31"] == 1000
+    assert result["income_statement"]["Net Income"]["2023-12-31"] == 100
+    assert "Unsupported Income Row" not in result["income_statement"]
+    assert result["balance_sheet"]["Total Assets"]["2024-12-31"] == 5000
+    assert result["balance_sheet"]["Total Debt"]["2023-12-31"] == 750
+    assert "Unsupported Balance Row" not in result["balance_sheet"]
+    assert result["cash_flow"]["Operating Cash Flow"]["2024-12-31"] == 300
+    assert result["cash_flow"]["Free Cash Flow"]["2023-12-31"] == 180
+    assert "Unsupported Cash Flow Row" not in result["cash_flow"]
+
+
+def test_build_financials_response_ignores_none_and_empty_dataframes() -> None:
+    """Test that missing or empty statements do not produce response sections."""
+    empty_df = pd.DataFrame()
+    income_stmt = _financials_df({"EBIT": [100, 90]})
+
+    partial_result = _build_financials_response(income_stmt, None, empty_df)
+    empty_result = _build_financials_response(None, empty_df, None)
+
+    assert set(partial_result) == {"income_statement"}
+    assert partial_result["income_statement"]["EBIT"]["2024-12-31"] == 100
+    assert empty_result == {}
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_financials_annual_success(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test annual financials retrieval."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.income_stmt = _financials_df({"Total Revenue": [1000, 900]})
+    mock_ticker_obj.balance_sheet = _financials_df({"Total Assets": [5000, 4500]})
+    mock_ticker_obj.cashflow = _financials_df({"Operating Cash Flow": [300, 280]})
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_financials("AAPL", "annual")
+    data = json.loads(result)
+
+    assert data["income_statement"]["Total Revenue"]["2024-12-31"] == 1000
+    assert data["balance_sheet"]["Total Assets"]["2023-12-31"] == 4500
+    assert data["cash_flow"]["Operating Cash Flow"]["2024-12-31"] == 300
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_financials_quarterly_success(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test quarterly financials retrieval."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.quarterly_income_stmt = _financials_df({"Operating Income": [400, 350]})
+    mock_ticker_obj.quarterly_balance_sheet = _financials_df({"Stockholders Equity": [2200, 2100]})
+    mock_ticker_obj.quarterly_cashflow = _financials_df({"Free Cash Flow": [150, 125]})
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_financials("MSFT", "quarterly")
+    data = json.loads(result)
+
+    assert data["income_statement"]["Operating Income"]["2024-12-31"] == 400
+    assert data["balance_sheet"]["Stockholders Equity"]["2023-12-31"] == 2100
+    assert data["cash_flow"]["Free Cash Flow"]["2024-12-31"] == 150
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_financials_ttm_success_only_income_statement(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock
+) -> None:
+    """Test TTM financials retrieval only returns income statement data."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.ttm_income_stmt = _financials_df({"EBITDA": [700, 650]})
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_financials("NVDA", "ttm")
+    data = json.loads(result)
+
+    assert set(data) == {"income_statement"}
+    assert data["income_statement"]["EBITDA"]["2024-12-31"] == 700
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_financials_invalid_frequency(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test invalid financials frequency returns structured parameter error."""
+    mock_ticker.return_value = MagicMock()
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_financials("AAPL", "monthly")
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"]["frequency"] == "monthly"
+    assert data["details"]["valid_options"] == ["annual", "quarterly", "ttm"]
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_financials_no_data(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test financials retrieval with no statement data."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.income_stmt = pd.DataFrame()
+    mock_ticker_obj.balance_sheet = pd.DataFrame()
+    mock_ticker_obj.cashflow = pd.DataFrame()
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_financials("EMPTY", "annual")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NO_DATA"
+    assert data["details"] == {"symbol": "EMPTY", "frequency": "annual"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), OSError("network unreachable")])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_financials_ticker_creation_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test network errors while creating a ticker return structured network errors."""
+    mock_ticker.side_effect = exception
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_financials("AAPL", "annual")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["details"]["symbol"] == "AAPL"
+    assert data["details"]["exception"] == str(exception)
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_financials_statement_read_api_error(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test statement read errors return structured API errors."""
+    mock_ticker.return_value = _FinancialsReadErrorTicker()
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_financials("AAPL", "annual")
+    data = json.loads(result)
+
+    assert data["error_code"] == "API_ERROR"
+    assert data["details"]["symbol"] == "AAPL"
+    assert data["details"]["frequency"] == "annual"
+    assert data["details"]["exception"] == "statement read failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds mock-based unit coverage for `yfinance_get_financials` and `_build_financials_response`.

## Details

- Covers annual, quarterly, and TTM financials responses without network calls.
- Verifies invalid frequency, no-data, network error, and API error paths.
- Adds builder coverage for supported sections, date keys, ignored unsupported rows, and missing or empty statements.

## Validation

- `uv run pytest tests/test_server_unit.py -v`
- `uv run ruff check tests/test_server_unit.py`
- `uv run ty check src tests`