### PR TITLE
[codex] Move mcp CLI extra to dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,3 @@ dmypy.json
 
 # Claude code
 .claude/
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers     = [
 dependencies    = [
   "loguru>=0.7.3",
   "matplotlib>=3.9.0",
-  "mcp[cli]>=1.26.0",
+  "mcp>=1.26.0",
   "yfinance>=1.2.0",
 ]
 
@@ -23,6 +23,7 @@ yfmcp = "yfmcp.server:main"
 
 [dependency-groups]
 dev = [
+  "mcp[cli]>=1.26.0",
   "pytest>=9.0.2",
   "pytest-asyncio>=1.3.0",
   "pytest-cov>=7.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1629,12 +1629,13 @@ source = { editable = "." }
 dependencies = [
     { name = "loguru" },
     { name = "matplotlib" },
-    { name = "mcp", extra = ["cli"] },
+    { name = "mcp" },
     { name = "yfinance" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "mcp", extra = ["cli"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1646,12 +1647,13 @@ dev = [
 requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "matplotlib", specifier = ">=3.9.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "mcp", specifier = ">=1.26.0" },
     { name = "yfinance", specifier = ">=1.2.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Summary

Move the `mcp[cli]` extra out of runtime dependencies and into the development dependency group. This keeps the published package runtime dependency lighter while preserving CLI tooling for development workflows.

Also includes the lockfile update and a `.gitignore` end-of-file formatting fix applied by pre-commit.

## Validation

- `uv run ruff check .`
- `uv run ty check src tests`
- `uv run pytest -q tests`
- `prek run -a`