### PR TITLE
Add option dates and option chain tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## Architecture Overview
 - MCP tools are exposed from `yfmcp.server` with `yfinance_`-prefixed names:
-  `yfinance_get_ticker_info`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`.
+  `yfinance_get_ticker_info`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`, `yfinance_get_option_chain`, `yfinance_get_option_dates`.
 - All blocking `yfinance` operations MUST be wrapped with `asyncio.to_thread()`.
 - Errors MUST be returned via `create_error_response()` with structured JSON (`error`, `error_code`, optional `details`).
 - Chart responses are returned as base64-encoded WebP `ImageContent`; tabular history uses Markdown tables.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that p
 - **Sector Rankings** — Top ETFs, mutual funds, companies, growth leaders, and top performers by sector
 - **Price History** — Historical OHLCV data as markdown tables or professional charts
 - **Chart Generation** — Candlestick, VWAP, and volume profile charts returned as WebP images
+- **Options Data** — Option chains with calls, puts, strike prices, IV, and expiration dates
 
 ## Tools
 
@@ -107,6 +108,38 @@ Fetch financial statements (income statement, balance sheet, and cash flow) with
 - **Income Statement fields**: EBIT, Net Income, Tax Provision, Pretax Income, Interest Expense, Total Revenue, Operating Income, EBITDA, Normalized Income
 - **Balance Sheet fields**: Stockholders Equity, Total Debt, Cash And Cash Equivalents, Invested Capital, Net Debt, Total Assets, Total Liabilities Net Minority Interest, Net Tangible Assets, Tangible Book Value
 - **Cash Flow fields**: Operating Cash Flow, Free Cash Flow, Capital Expenditure, Net Income From Continuing Operations, Depreciation And Amortization, Change In Working Capital, Cash Dividends Paid
+
+### `yfinance_get_option_dates`
+
+Fetch available option expiration dates for a stock.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | Yes | Stock ticker symbol (e.g. `AAPL`, `MSFT`) |
+
+**Returns:** JSON array of expiration dates in YYYY-MM-DD format.
+
+### `yfinance_get_option_chain`
+
+Fetch option chain data (calls and puts) for a stock with available strike prices.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | Yes | Stock ticker symbol |
+| `expiration_date` | string | No | Option expiration date in YYYY-MM-DD format. Omit to fetch all dates. |
+| `option_type` | string | No | `"calls"`, `"puts"`, or `"all"` (default: `"all"`) |
+
+**Returns:** JSON object keyed by expiration date, with calls and/or puts data including:
+- `contractSymbol`: Option contract identifier
+- `strike`: Strike price
+- `lastPrice`: Last traded price
+- `bid`/`ask`: Bid and ask prices
+- `volume`: Trading volume
+- `openInterest`: Open interest
+- `impliedVolatility`: IV
+- `inTheMoney`: Whether option is ITM
+- `contractSize`: Contract size (REGULAR)
+- `currency`: Currency (USD)
 
 ## Usage
 

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime
 from typing import Annotated
+from typing import Any
 
 import yfinance as yf
 from loguru import logger
@@ -13,6 +14,7 @@ from yfinance.const import SECTOR_INDUSTY_MAPPING
 from yfmcp.chart import generate_chart
 from yfmcp.types import ChartType
 from yfmcp.types import Interval
+from yfmcp.types import OptionChainType
 from yfmcp.types import Period
 from yfmcp.types import SearchType
 from yfmcp.types import Sector
@@ -761,6 +763,185 @@ def _build_financials_response(income_stmt, balance_sheet, cash_flow=None) -> di
             result["cash_flow"][field] = {str(col.date()): cash_flow.loc[field, col] for col in cash_flow.columns}
 
     return result
+
+
+async def _fetch_option_chain_for_date(
+    ticker: yf.Ticker,
+    date: str,
+    option_type: OptionChainType,
+) -> dict[str, Any]:
+    """Fetch option chain for a single expiration date."""
+    try:
+        opt = await asyncio.to_thread(lambda d=date: ticker.option_chain(d))
+    except Exception as exc:
+        logger.warning("Failed to fetch option chain for {} {}: {}", ticker, date, exc)
+        return {}
+
+    calls_df = opt.calls
+    puts_df = opt.puts
+    date_data: dict[str, Any] = {}
+
+    if calls_df is not None and not calls_df.empty and option_type in {"all", "calls"}:
+        calls_df = calls_df.copy()
+        calls_df["optionType"] = "CALL"
+        date_data["calls"] = calls_df.to_dict(orient="records")
+
+    if puts_df is not None and not puts_df.empty and option_type in {"all", "puts"}:
+        puts_df = puts_df.copy()
+        puts_df["optionType"] = "PUT"
+        date_data["puts"] = puts_df.to_dict(orient="records")
+
+    return {date: date_data} if date_data else {}
+
+
+@mcp.tool(
+    name="yfinance_get_option_chain",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def get_option_chain(
+    symbol: Annotated[str, Field(description="Stock ticker symbol (e.g., 'AAPL', 'GOOGL', 'MSFT')")],
+    expiration_date: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Option expiration date in YYYY-MM-DD format. "
+                "Use the 'yfinance_get_option_dates' tool to find available dates, "
+                "or omit to fetch all available expiration dates."
+            )
+        ),
+    ] = None,
+    option_type: Annotated[
+        OptionChainType,
+        Field(description=("Which options to return: 'calls', 'puts', or 'all' (both calls and puts).")),
+    ] = "all",
+) -> str:
+    """Fetch option chain data (calls and puts) for a stock with available strike prices.
+
+    Returns JSON with calls and/or puts data for each expiration date.
+
+    JSON fields include:
+    - contractSymbol: Option contract identifier
+    - strike: Strike price
+    - lastPrice: Last traded price
+    - bid/ask: Bid and ask prices
+    - volume: Trading volume
+    - openInterest: Open interest
+    - impliedVolatility: Implied volatility (IV)
+    - inTheMoney: Whether option is ITM
+    - contractSize: Contract size (REGULAR)
+    - currency: Currency (USD)
+
+    Use this to analyze options pricing, IV surfaces, and strike levels.
+    """
+    try:
+        ticker = await asyncio.to_thread(yf.Ticker, symbol)
+    except (ConnectionError, TimeoutError, OSError) as exc:
+        return create_error_response(
+            f"Network error while fetching options for '{symbol}'. Check your internet connection and try again.",
+            error_code="NETWORK_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch options for '{symbol}'. Verify the symbol is correct.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    try:
+        available_dates = await asyncio.to_thread(lambda: ticker.options)
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch option dates for '{symbol}'. The symbol may not have options.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    if not available_dates:
+        return create_error_response(
+            f"No options available for symbol '{symbol}'. "
+            "This symbol may not have listed options (e.g., ETFs, stocks without options).",
+            error_code="NO_DATA",
+            details={"symbol": symbol},
+        )
+
+    if expiration_date is not None and expiration_date not in available_dates:
+        return create_error_response(
+            f"Invalid expiration date '{expiration_date}' for '{symbol}'. Valid dates: {', '.join(available_dates)}",
+            error_code="INVALID_PARAMS",
+            details={
+                "symbol": symbol,
+                "expiration_date": expiration_date,
+                "valid_dates": available_dates,
+            },
+        )
+
+    dates_to_fetch = [expiration_date] if expiration_date else available_dates
+    result: dict[str, Any] = {}
+
+    for date in dates_to_fetch:
+        date_result = await _fetch_option_chain_for_date(ticker, date, option_type)
+        result.update(date_result)
+
+    if not result:
+        return create_error_response(
+            f"No option data retrieved for '{symbol}'.",
+            error_code="NO_DATA",
+            details={"symbol": symbol, "dates_requested": list(dates_to_fetch)},
+        )
+
+    return dump_json(result)
+
+
+@mcp.tool(
+    name="yfinance_get_option_dates",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def get_option_dates(
+    symbol: Annotated[str, Field(description="Stock ticker symbol (e.g., 'AAPL', 'GOOGL', 'MSFT')")],
+) -> str:
+    """Fetch available option expiration dates for a stock.
+
+    Returns JSON array of expiration dates in YYYY-MM-DD format.
+
+    Use these dates with the 'yfinance_get_option_chain' tool to fetch
+    the options chain for a specific date.
+    """
+    try:
+        ticker = await asyncio.to_thread(yf.Ticker, symbol)
+        dates = await asyncio.to_thread(lambda: ticker.options)
+    except (ConnectionError, TimeoutError, OSError) as exc:
+        return create_error_response(
+            f"Network error while fetching option dates for '{symbol}'. Check your internet connection and try again.",
+            error_code="NETWORK_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch option dates for '{symbol}'. Verify the symbol is correct.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    if not dates:
+        return create_error_response(
+            f"No options available for symbol '{symbol}'. "
+            "This symbol may not have listed options (e.g., ETFs, stocks without options).",
+            error_code="NO_DATA",
+            details={"symbol": symbol},
+        )
+
+    return dump_json(dates)
 
 
 def main() -> None:

--- a/src/yfmcp/types.py
+++ b/src/yfmcp/types.py
@@ -78,3 +78,9 @@ ChartType = Literal[
     "vwap",
     "volume_profile",
 ]
+
+OptionChainType = Literal[
+    "calls",
+    "puts",
+    "all",
+]

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -11,9 +11,9 @@ import pytest
 
 from yfmcp.server import _build_financials_response
 from yfmcp.server import get_financials
-from yfmcp.server import get_price_history
 from yfmcp.server import get_option_chain
 from yfmcp.server import get_option_dates
+from yfmcp.server import get_price_history
 from yfmcp.server import get_top_companies
 from yfmcp.server import get_top_etfs
 from yfmcp.server import get_top_growth_companies

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import PropertyMock
 from unittest.mock import patch
 
 import pandas as pd
@@ -11,6 +12,8 @@ import pytest
 from yfmcp.server import _build_financials_response
 from yfmcp.server import get_financials
 from yfmcp.server import get_price_history
+from yfmcp.server import get_option_chain
+from yfmcp.server import get_option_dates
 from yfmcp.server import get_top_companies
 from yfmcp.server import get_top_etfs
 from yfmcp.server import get_top_growth_companies
@@ -479,3 +482,321 @@ async def test_get_top_growth_companies_no_industries() -> None:
 
     assert "error" in data
     assert data["error_code"] == "NO_DATA"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_dates_success(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test successful option dates retrieval."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02", "2025-05-09", "2025-05-16"]
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_dates("AAPL")
+    data = json.loads(result)
+
+    assert isinstance(data, list)
+    assert len(data) == 3
+    assert "2025-05-02" in data
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_dates_no_options(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test option dates with stock that has no options."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = []
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_dates("SPY")
+    data = json.loads(result)
+
+    assert "error" in data
+    assert data["error_code"] == "NO_DATA"
+
+
+def _option_df() -> pd.DataFrame:
+    """Build a yfinance-shaped option DataFrame."""
+    return pd.DataFrame(
+        {
+            "contractSymbol": ["AAPL250515C00150000", "AAPL250515C00160000"],
+            "strike": [150.0, 160.0],
+            "lastPrice": [10.5, 5.2],
+            "bid": [10.3, 5.0],
+            "ask": [10.7, 5.4],
+            "volume": [100, 50],
+            "openInterest": [200, 100],
+            "impliedVolatility": [0.30, 0.35],
+            "inTheMoney": [True, False],
+            "contractSize": ["REGULAR", "REGULAR"],
+            "currency": ["USD", "USD"],
+        }
+    )
+
+
+class _MockOptionChain:
+    def __init__(self):
+        self.calls = _option_df()
+        self.puts = _option_df()
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_success_all(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test successful option chain retrieval for all dates and types."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02", "2025-05-09"]
+    mock_opt = _MockOptionChain()
+    mock_ticker_obj.option_chain.return_value = mock_opt
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL")
+    data = json.loads(result)
+
+    assert "2025-05-02" in data
+    assert "calls" in data["2025-05-02"]
+    assert "puts" in data["2025-05-02"]
+    assert data["2025-05-02"]["calls"][0]["optionType"] == "CALL"
+    assert data["2025-05-02"]["puts"][0]["optionType"] == "PUT"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_specific_date(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test option chain with specific expiration date."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02", "2025-05-09"]
+    mock_opt = _MockOptionChain()
+    mock_ticker_obj.option_chain.return_value = mock_opt
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL", expiration_date="2025-05-02")
+    data = json.loads(result)
+
+    assert "2025-05-02" in data
+    assert len(data) == 1
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_invalid_date(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test option chain with invalid expiration date."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02", "2025-05-09"]
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL", expiration_date="2025-06-01")
+    data = json.loads(result)
+
+    assert "error" in data
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert "valid_dates" in data["details"]
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_no_options(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test option chain with stock that has no options."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = []
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("SPY")
+    data = json.loads(result)
+
+    assert "error" in data
+    assert data["error_code"] == "NO_DATA"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_calls_only(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test option chain returning calls only."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02"]
+    mock_opt = _MockOptionChain()
+    mock_ticker_obj.option_chain.return_value = mock_opt
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL", option_type="calls")
+    data = json.loads(result)
+
+    assert "2025-05-02" in data
+    assert "calls" in data["2025-05-02"]
+    assert "puts" not in data["2025-05-02"]
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_puts_only_calls_empty(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test scenario where calls are empty but puts are present."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02"]
+
+    mock_opt = MagicMock()
+    mock_opt.calls = pd.DataFrame()
+    mock_opt.puts = pd.DataFrame(
+        {
+            "contractSymbol": ["AAPL250515P00150000"],
+            "strike": [150.0],
+        }
+    )
+
+    mock_ticker_obj.option_chain.return_value = mock_opt
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL", option_type="puts")
+    data = json.loads(result)
+
+    assert "2025-05-02" in data
+    assert "puts" in data["2025-05-02"]
+    assert "calls" not in data["2025-05-02"]
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_no_matching_type(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test scenario where requested type (e.g. calls) has no data for any date."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02"]
+
+    mock_opt = MagicMock()
+    mock_opt.calls = pd.DataFrame()  # No calls
+    mock_opt.puts = pd.DataFrame({"strike": [150.0]})  # Has puts
+
+    mock_ticker_obj.option_chain.return_value = mock_opt
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    # Request calls only, but only puts exist
+    result = await get_option_chain("AAPL", option_type="calls")
+    data = json.loads(result)
+
+    assert "error" in data
+    assert data["error_code"] == "NO_DATA"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), OSError("network unreachable")])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_dates_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test network errors while fetching option dates."""
+    mock_ticker.side_effect = exception
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_dates("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["details"]["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_dates_api_error(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test generic API errors while fetching option dates."""
+    mock_ticker.side_effect = Exception("generic error")
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_dates("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "API_ERROR"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), OSError("network unreachable")])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_ticker_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test network errors during ticker creation in get_option_chain."""
+    mock_ticker.side_effect = exception
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["details"]["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_dates_fetch_error(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test error during available_dates fetch in get_option_chain."""
+    mock_ticker_obj = MagicMock()
+    # Mocking a property that raises Exception
+    type(mock_ticker_obj).options = PropertyMock(side_effect=Exception("dates failed"))
+
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "API_ERROR"
+    assert "Failed to fetch option dates" in data["error"]
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_partial_failure(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test get_option_chain when one date fails but another succeeds."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02", "2025-05-09"]
+
+    mock_opt = _MockOptionChain()
+
+    # We need a custom side effect to make one call fail
+    async def side_effect(func, *args, **kwargs):
+        if not hasattr(side_effect, "ticker_created"):
+            side_effect.ticker_created = True
+            return mock_ticker_obj
+
+        if callable(func):
+            res = func()
+            if res == mock_ticker_obj.options:
+                return ["2025-05-02", "2025-05-09"]
+
+            # This is the ticker.option_chain(date) call
+            # We'll make the first date fail
+            if not hasattr(side_effect, "fetch_called"):
+                side_effect.fetch_called = True
+                raise RuntimeError("Fetch failed for first date")
+            return mock_opt
+        return mock_ticker_obj
+
+    mock_to_thread.side_effect = side_effect
+    mock_ticker.return_value = mock_ticker_obj
+
+    result = await get_option_chain("AAPL")
+    data = json.loads(result)
+
+    # Should have data for the second date but not the first
+    assert "2025-05-09" in data
+    assert "2025-05-02" not in data


### PR DESCRIPTION
Adds `yfinance_get_option_dates` and `yfinance_get_option_chain`, allowing the user to query available options data (US only for Yahoo).