### PR TITLE
[codex] Add option chain tools with retryable error handling

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,5 @@
+## GOTCHA
+
+- `ticker.options` and `ticker.option_chain()` can raise timeout, connection-related errors, or `YFRateLimitError`; in the options tools these must remain `NETWORK_ERROR` and must not be downgraded to `NO_DATA` or generic `API_ERROR`.
+
+## TASTE

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -10,6 +10,7 @@ from mcp.types import ImageContent
 from mcp.types import ToolAnnotations
 from pydantic import Field
 from yfinance.const import SECTOR_INDUSTY_MAPPING
+from yfinance.exceptions import YFRateLimitError
 
 from yfmcp.chart import generate_chart
 from yfmcp.types import ChartType
@@ -24,6 +25,85 @@ from yfmcp.utils import dump_json
 
 # https://github.com/jlowin/fastmcp/issues/81#issuecomment-2714245145
 mcp = FastMCP("yfinance_mcp", log_level="ERROR")
+
+
+_RETRYABLE_YFINANCE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    ConnectionError,
+    TimeoutError,
+    OSError,
+    YFRateLimitError,
+)
+
+
+def _is_retryable_yfinance_error(exc: Exception) -> bool:
+    return isinstance(exc, _RETRYABLE_YFINANCE_EXCEPTIONS)
+
+
+def _create_option_dates_fetch_error(symbol: str, exc: Exception, api_message: str) -> str:
+    if _is_retryable_yfinance_error(exc):
+        return create_error_response(
+            f"Network error while fetching option dates for '{symbol}'. "
+            "Check your internet connection and try again.",
+            error_code="NETWORK_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    return create_error_response(
+        api_message,
+        error_code="API_ERROR",
+        details={"symbol": symbol, "exception": str(exc)},
+    )
+
+
+def _create_option_chain_fetch_error(
+    symbol: str,
+    dates_to_fetch: list[str],
+    fetch_errors: list[tuple[str, Exception]],
+) -> str:
+    failed_dates = [date for date, _ in fetch_errors]
+
+    if len(dates_to_fetch) == 1:
+        failed_date, exc = fetch_errors[0]
+        if _is_retryable_yfinance_error(exc):
+            return create_error_response(
+                f"Network error while fetching option chain for '{symbol}' on '{failed_date}'. "
+                "Check your internet connection and try again.",
+                error_code="NETWORK_ERROR",
+                details={"symbol": symbol, "expiration_date": failed_date, "exception": str(exc)},
+            )
+
+        return create_error_response(
+            f"Failed to fetch option chain for '{symbol}' on '{failed_date}'.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "expiration_date": failed_date, "exception": str(exc)},
+        )
+
+    network_exception = next((exc for _, exc in fetch_errors if _is_retryable_yfinance_error(exc)), None)
+    representative_exception = network_exception or fetch_errors[0][1]
+
+    if network_exception is not None:
+        return create_error_response(
+            f"Network error while fetching option chain for '{symbol}'. "
+            "Check your internet connection and try again.",
+            error_code="NETWORK_ERROR",
+            details={
+                "symbol": symbol,
+                "dates_requested": dates_to_fetch,
+                "failed_dates": failed_dates,
+                "exception": str(representative_exception),
+            },
+        )
+
+    return create_error_response(
+        f"Failed to fetch option chain for '{symbol}' for all requested dates.",
+        error_code="API_ERROR",
+        details={
+            "symbol": symbol,
+            "dates_requested": dates_to_fetch,
+            "failed_dates": failed_dates,
+            "exception": str(representative_exception),
+        },
+    )
 
 
 @mcp.tool(
@@ -771,11 +851,7 @@ async def _fetch_option_chain_for_date(
     option_type: OptionChainType,
 ) -> dict[str, Any]:
     """Fetch option chain for a single expiration date."""
-    try:
-        opt = await asyncio.to_thread(lambda d=date: ticker.option_chain(d))
-    except Exception as exc:
-        logger.warning("Failed to fetch option chain for {} {}: {}", ticker, date, exc)
-        return {}
+    opt = await asyncio.to_thread(lambda d=date: ticker.option_chain(d))
 
     calls_df = opt.calls
     puts_df = opt.puts
@@ -856,10 +932,10 @@ async def get_option_chain(
     try:
         available_dates = await asyncio.to_thread(lambda: ticker.options)
     except Exception as exc:
-        return create_error_response(
+        return _create_option_dates_fetch_error(
+            symbol,
+            exc,
             f"Failed to fetch option dates for '{symbol}'. The symbol may not have options.",
-            error_code="API_ERROR",
-            details={"symbol": symbol, "exception": str(exc)},
         )
 
     if not available_dates:
@@ -881,21 +957,30 @@ async def get_option_chain(
             },
         )
 
-    dates_to_fetch = [expiration_date] if expiration_date else available_dates
+    dates_to_fetch = [expiration_date] if expiration_date else list(available_dates)
     result: dict[str, Any] = {}
+    fetch_errors: list[tuple[str, Exception]] = []
 
     for date in dates_to_fetch:
-        date_result = await _fetch_option_chain_for_date(ticker, date, option_type)
+        try:
+            date_result = await _fetch_option_chain_for_date(ticker, date, option_type)
+        except Exception as exc:
+            logger.warning("Failed to fetch option chain for {} {}: {}", symbol, date, exc)
+            fetch_errors.append((date, exc))
+            continue
         result.update(date_result)
 
-    if not result:
-        return create_error_response(
-            f"No option data retrieved for '{symbol}'.",
-            error_code="NO_DATA",
-            details={"symbol": symbol, "dates_requested": list(dates_to_fetch)},
-        )
+    if result:
+        return dump_json(result)
 
-    return dump_json(result)
+    if fetch_errors:
+        return _create_option_chain_fetch_error(symbol, dates_to_fetch, fetch_errors)
+
+    return create_error_response(
+        f"No option data retrieved for '{symbol}'.",
+        error_code="NO_DATA",
+        details={"symbol": symbol, "dates_requested": list(dates_to_fetch)},
+    )
 
 
 @mcp.tool(
@@ -920,17 +1005,11 @@ async def get_option_dates(
     try:
         ticker = await asyncio.to_thread(yf.Ticker, symbol)
         dates = await asyncio.to_thread(lambda: ticker.options)
-    except (ConnectionError, TimeoutError, OSError) as exc:
-        return create_error_response(
-            f"Network error while fetching option dates for '{symbol}'. Check your internet connection and try again.",
-            error_code="NETWORK_ERROR",
-            details={"symbol": symbol, "exception": str(exc)},
-        )
     except Exception as exc:
-        return create_error_response(
+        return _create_option_dates_fetch_error(
+            symbol,
+            exc,
             f"Failed to fetch option dates for '{symbol}'. Verify the symbol is correct.",
-            error_code="API_ERROR",
-            details={"symbol": symbol, "exception": str(exc)},
         )
 
     if not dates:

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from yfinance.exceptions import YFRateLimitError
 
 from yfmcp.server import _build_financials_response
 from yfmcp.server import get_financials
@@ -519,6 +520,26 @@ async def test_get_option_dates_no_options(mock_to_thread: AsyncMock, mock_ticke
     assert data["error_code"] == "NO_DATA"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), YFRateLimitError()])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_dates_options_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test network errors while reading ticker.options in get_option_dates."""
+    mock_ticker_obj = MagicMock()
+    type(mock_ticker_obj).options = PropertyMock(side_effect=exception)
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_dates("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert "Network error while fetching option dates" in data["error"]
+
+
 def _option_df() -> pd.DataFrame:
     """Build a yfinance-shaped option DataFrame."""
     return pd.DataFrame(
@@ -746,8 +767,8 @@ async def test_get_option_chain_ticker_network_error(
 @pytest.mark.asyncio
 @patch("yfmcp.server.yf.Ticker")
 @patch("yfmcp.server.asyncio.to_thread")
-async def test_get_option_chain_dates_fetch_error(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
-    """Test error during available_dates fetch in get_option_chain."""
+async def test_get_option_chain_dates_fetch_api_error(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test API error during available_dates fetch in get_option_chain."""
     mock_ticker_obj = MagicMock()
     # Mocking a property that raises Exception
     type(mock_ticker_obj).options = PropertyMock(side_effect=Exception("dates failed"))
@@ -760,6 +781,27 @@ async def test_get_option_chain_dates_fetch_error(mock_to_thread: AsyncMock, moc
 
     assert data["error_code"] == "API_ERROR"
     assert "Failed to fetch option dates" in data["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), YFRateLimitError()])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_dates_fetch_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test network error during available_dates fetch in get_option_chain."""
+    mock_ticker_obj = MagicMock()
+    type(mock_ticker_obj).options = PropertyMock(side_effect=exception)
+
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert "Network error while fetching option dates" in data["error"]
 
 
 @pytest.mark.asyncio
@@ -800,3 +842,45 @@ async def test_get_option_chain_partial_failure(mock_to_thread: AsyncMock, mock_
     # Should have data for the second date but not the first
     assert "2025-05-09" in data
     assert "2025-05-02" not in data
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), YFRateLimitError()])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_specific_date_fetch_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test a single-date option chain fetch failure remains retryable."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02"]
+    mock_ticker_obj.option_chain.side_effect = exception
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL", expiration_date="2025-05-02")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["details"]["expiration_date"] == "2025-05-02"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), YFRateLimitError()])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_option_chain_all_dates_fetch_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test all-date option chain fetch failures remain retryable."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.options = ["2025-05-02", "2025-05-09"]
+    mock_ticker_obj.option_chain.side_effect = exception
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_option_chain("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["details"]["failed_dates"] == ["2025-05-02", "2025-05-09"]


### PR DESCRIPTION
## Summary

- add option dates and option chain MCP tools
- preserve retryable upstream failures as NETWORK_ERROR instead of masking them as NO_DATA or API_ERROR
- add unit coverage for option date fetch failures, single-date fetch failures, and all-date fetch failures

## Root Cause

- single-date ticker.option_chain() failures were swallowed and surfaced as empty results
- ticker.options transient failures, including rate limits, were collapsed into API_ERROR

## Impact

- callers can now distinguish retryable failures from real no-data responses
- option chain requests still return partial data when some expiration dates succeed

## Validation

- uv run ruff check src/yfmcp/server.py tests/test_server_unit.py
- uv run ty check src tests
- uv run pytest -v -s tests/test_server_unit.py
