### PR TITLE
feat: get holders tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## Architecture Overview
 - MCP tools are exposed from `yfmcp.server` with `yfinance_`-prefixed names:
-  `yfinance_get_ticker_info`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`, `yfinance_get_option_chain`, `yfinance_get_option_dates`.
+  `yfinance_get_ticker_info`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`, `yfinance_get_holders`, `yfinance_get_option_chain`, `yfinance_get_option_dates`.
 - All blocking `yfinance` operations MUST be wrapped with `asyncio.to_thread()`.
 - Errors MUST be returned via `create_error_response()` with structured JSON (`error`, `error_code`, optional `details`).
 - Chart responses are returned as base64-encoded WebP `ImageContent`; tabular history uses Markdown tables.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that p
 - **Price History** — Historical OHLCV data as markdown tables or professional charts
 - **Chart Generation** — Candlestick, VWAP, and volume profile charts returned as WebP images
 - **Options Data** — Option chains with calls, puts, strike prices, IV, and expiration dates
+- **Ownership Data** — Major holders, institutional investors, mutual fund holders, and insider transactions
 
 ## Tools
 
@@ -108,6 +109,22 @@ Fetch financial statements (income statement, balance sheet, and cash flow) with
 - **Income Statement fields**: EBIT, Net Income, Tax Provision, Pretax Income, Interest Expense, Total Revenue, Operating Income, EBITDA, Normalized Income
 - **Balance Sheet fields**: Stockholders Equity, Total Debt, Cash And Cash Equivalents, Invested Capital, Net Debt, Total Assets, Total Liabilities Net Minority Interest, Net Tangible Assets, Tangible Book Value
 - **Cash Flow fields**: Operating Cash Flow, Free Cash Flow, Capital Expenditure, Net Income From Continuing Operations, Depreciation And Amortization, Change In Working Capital, Cash Dividends Paid
+
+### `yfinance_get_holders`
+
+Fetch major holders, institutional holders, mutual fund holders, and insider data.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | Yes | Stock ticker symbol (e.g. `AAPL`, `MSFT`) |
+
+**Returns:** JSON object with:
+- **`major_holders`** — Aggregated breakdown where each row has an `index` label (e.g. `insidersPercentHeld`, `institutionsPercentHeld`, `institutionsFloatPercentHeld`, `institutionsCount`) and a `Value`
+- **`institutional_holders`** — Institutional investors with fields: `Date Reported`, `Holder`, `Shares`, `Value`, `pctChange`, `pctHeld`
+- **`mutualfund_holders`** — Mutual fund holders with same fields as institutional holders
+- **`insider_transactions`** — Recent insider trades with fields: `Shares`, `Value`, `Insider`, `Position`, `Transaction`, `Start Date`, `Ownership`
+- **`insider_purchases`** — Six-month summary where each row describes a category (Purchases, Sales, Net Shares, etc.) with fields: `Insider Purchases Last 6m`, `Shares`, `Trans`
+- **`insider_roster`** — Known insiders with fields: `Name`, `Position`, `Shares Owned Directly`, `Most Recent Transaction`, `Latest Transaction Date`
 
 ### `yfinance_get_option_dates`
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,13 @@ Fetch major holders, institutional holders, mutual fund holders, and insider dat
 
 **Returns:** JSON object with:
 - **`major_holders`** — Aggregated breakdown where each row has an `index` label (e.g. `insidersPercentHeld`, `institutionsPercentHeld`, `institutionsFloatPercentHeld`, `institutionsCount`) and a `Value`
-- **`institutional_holders`** — Institutional investors with fields: `Date Reported`, `Holder`, `Shares`, `Value`, `pctChange`, `pctHeld`
-- **`mutualfund_holders`** — Mutual fund holders with same fields as institutional holders
-- **`insider_transactions`** — Recent insider trades with fields: `Shares`, `Value`, `Insider`, `Position`, `Transaction`, `Start Date`, `Ownership`
-- **`insider_purchases`** — Six-month summary where each row describes a category (Purchases, Sales, Net Shares, etc.) with fields: `Insider Purchases Last 6m`, `Shares`, `Trans`
-- **`insider_roster`** — Known insiders with fields: `Name`, `Position`, `Shares Owned Directly`, `Most Recent Transaction`, `Latest Transaction Date`
+- **`institutional_holders`** — Institutional investors; records typically include fields such as `Date Reported`, `Holder`, `Shares`, `Value`, `pctChange`, `pctHeld`
+- **`mutualfund_holders`** — Mutual fund holders; records typically include fields similar to institutional holders
+- **`insider_transactions`** — Recent insider trades; records typically include fields such as `Shares`, `Value`, `Insider`, `Position`, `Transaction`, `Start Date`, `Ownership`
+- **`insider_purchases`** — Six-month summary where each row describes a category (Purchases, Sales, Net Shares, etc.); records typically include fields such as `Insider Purchases Last 6m`, `Shares`, `Trans`
+- **`insider_roster`** — Known insiders; records typically include fields such as `Name`, `Position`, `Shares Owned Directly`, `Most Recent Transaction`, `Latest Transaction Date`
+
+Field names for holder-related datasets are provided by `yfinance` and may vary by ticker, data availability, and `yfinance` version.
 
 ### `yfinance_get_option_dates`
 

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -999,5 +999,80 @@ async def get_option_dates(
     return dump_json(dates)
 
 
+async def _fetch_holder_section(
+    symbol: str,
+    ticker: yf.Ticker,
+    attr_name: str,
+    result_key: str,
+    result: dict[str, Any],
+) -> None:
+    """Fetch a single holder data section from the ticker, mutating result on success."""
+    try:
+        df = await asyncio.to_thread(lambda t=ticker: getattr(t, attr_name))
+    except Exception as exc:
+        logger.warning("Failed to fetch {} for {}: {}", attr_name, symbol, exc)
+        return
+    if df is not None and not df.empty:
+        if attr_name == "major_holders":
+            df = df.reset_index()
+        result[result_key] = df.to_dict(orient="records")
+
+
+@mcp.tool(
+    name="yfinance_get_holders",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def get_holders(
+    symbol: Annotated[str, Field(description="Stock ticker symbol (e.g., 'AAPL', 'GOOGL', 'MSFT')")],
+) -> str:
+    """Fetch major holders, institutional holders, mutual fund holders, and insider data.
+
+    Returns JSON with:
+    - major_holders: Aggregated breakdown including insider % held, institutional % held,
+      institutional % float held, and institution count.
+    - institutional_holders: List of institutional investors with shares held, date reported,
+      value, and % change.
+    - mutualfund_holders: List of mutual fund holders with same fields.
+    - insider_transactions: Recent insider transactions including shares, value, transaction
+      type, and date.
+    - insider_purchases: Summary of insider buy/sell activity over the last 6 months.
+    - insider_roster: List of known insiders by name and position.
+
+    Use this to analyze ownership concentration, insider activity, and institutional interest.
+    """
+    try:
+        ticker = await asyncio.to_thread(yf.Ticker, symbol)
+    except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
+        return _create_retryable_error_response(f"fetching holders for '{symbol}'", exc, {"symbol": symbol})
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch holders for '{symbol}'. Verify the symbol is correct.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    result: dict[str, Any] = {}
+    await _fetch_holder_section(symbol, ticker, "major_holders", "major_holders", result)
+    await _fetch_holder_section(symbol, ticker, "institutional_holders", "institutional_holders", result)
+    await _fetch_holder_section(symbol, ticker, "mutualfund_holders", "mutualfund_holders", result)
+    await _fetch_holder_section(symbol, ticker, "insider_transactions", "insider_transactions", result)
+    await _fetch_holder_section(symbol, ticker, "insider_purchases", "insider_purchases", result)
+    await _fetch_holder_section(symbol, ticker, "insider_roster_holders", "insider_roster", result)
+
+    if not result:
+        return create_error_response(
+            f"No holder data available for '{symbol}'. Verify the symbol is correct.",
+            error_code="NO_DATA",
+            details={"symbol": symbol},
+        )
+
+    return dump_json(result)
+
+
 def main() -> None:
     mcp.run()

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -12,6 +12,7 @@ from yfinance.exceptions import YFRateLimitError
 
 from yfmcp.server import _build_financials_response
 from yfmcp.server import get_financials
+from yfmcp.server import get_holders
 from yfmcp.server import get_option_chain
 from yfmcp.server import get_option_dates
 from yfmcp.server import get_price_history
@@ -907,3 +908,197 @@ async def test_get_option_chain_all_dates_fetch_network_error(
     assert data["error_code"] == "NETWORK_ERROR"
     assert data["error"] == _expected_retryable_error("fetching option chain for 'AAPL'", exception)
     assert data["details"]["failed_dates"] == ["2025-05-02", "2025-05-09"]
+
+
+def _major_holders_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"Value": [0.0015, 0.65, 0.66, 7540.0]},
+        index=["insidersPercentHeld", "institutionsPercentHeld", "institutionsFloatPercentHeld", "institutionsCount"],
+    )
+
+
+def _institutional_holders_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Date Reported": ["2025-12-31", "2025-12-31"],
+            "Holder": ["Vanguard Group Inc", "Blackrock Inc."],
+            "Shares": [100_000_000, 80_000_000],
+            "Value": [20_000_000_000, 16_000_000_000],
+            "pctChange": [0.019, 0.007],
+        }
+    )
+
+
+def _mutualfund_holders_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Date Reported": ["2025-12-31"],
+            "Holder": ["Fidelity 500 Index"],
+            "Shares": [10_000_000],
+            "Value": [2_000_000_000],
+            "pctChange": [-0.01],
+        }
+    )
+
+
+def _insider_transactions_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Shares": [10_000, 5_000],
+            "Value": [2_000_000, 1_000_000],
+            "Start Date": ["2025-12-01", "2025-11-15"],
+            "Transaction": ["Sale", "Purchase"],
+            "Insider": ["COOK TIMOTHY D", "ADAMS KATHERINE L"],
+        }
+    )
+
+
+def _insider_purchases_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Insider Purchases Last 6m": ["Purchases", "Sales", "Net Shares Purchased (Sold)"],
+            "Shares": [50_000.0, 15_000.0, 35_000.0],
+        }
+    )
+
+
+def _insider_roster_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Name": ["COOK TIMOTHY D", "KHAN SABIH"],
+            "Position": ["Chief Executive Officer", "SVP, General Counsel"],
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_holders_success_all_sections(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test successful holders retrieval with all data sections."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.major_holders = _major_holders_df()
+    mock_ticker_obj.institutional_holders = _institutional_holders_df()
+    mock_ticker_obj.mutualfund_holders = _mutualfund_holders_df()
+    mock_ticker_obj.insider_transactions = _insider_transactions_df()
+    mock_ticker_obj.insider_purchases = _insider_purchases_df()
+    mock_ticker_obj.insider_roster_holders = _insider_roster_df()
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_holders("AAPL")
+    data = json.loads(result)
+
+    assert "major_holders" in data
+    assert "institutional_holders" in data
+    assert "mutualfund_holders" in data
+    assert "insider_transactions" in data
+    assert "insider_purchases" in data
+    assert "insider_roster" in data
+
+    assert data["major_holders"][0] == {"index": "insidersPercentHeld", "Value": 0.0015}
+    assert data["major_holders"][1] == {"index": "institutionsPercentHeld", "Value": 0.65}
+
+    # Spot check institutional holder
+    assert data["institutional_holders"][0]["Holder"] == "Vanguard Group Inc"
+    assert data["institutional_holders"][0]["Shares"] == 100_000_000
+
+    # Spot check insider roster
+    assert data["insider_roster"][0]["Name"] == "COOK TIMOTHY D"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_holders_partial_data(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test holders retrieval where some sections are empty DataFrames."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.major_holders = _major_holders_df()
+    mock_ticker_obj.institutional_holders = pd.DataFrame()
+    mock_ticker_obj.mutualfund_holders = None
+    mock_ticker_obj.insider_transactions = _insider_transactions_df()
+    mock_ticker_obj.insider_purchases = pd.DataFrame()
+    mock_ticker_obj.insider_roster_holders = None
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_holders("AAPL")
+    data = json.loads(result)
+
+    assert "major_holders" in data
+    assert "insider_transactions" in data
+    assert "institutional_holders" not in data
+    assert "mutualfund_holders" not in data
+    assert "insider_purchases" not in data
+    assert "insider_roster" not in data
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_holders_no_data(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test holders retrieval with no data at all."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.major_holders = None
+    mock_ticker_obj.institutional_holders = pd.DataFrame()
+    mock_ticker_obj.mutualfund_holders = None
+    mock_ticker_obj.insider_transactions = pd.DataFrame()
+    mock_ticker_obj.insider_purchases = None
+    mock_ticker_obj.insider_roster_holders = None
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_holders("EMPTY")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NO_DATA"
+    assert data["details"]["symbol"] == "EMPTY"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), OSError("network unreachable"), YFRateLimitError()])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_holders_ticker_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test network errors during ticker creation return structured network errors."""
+    mock_ticker.side_effect = exception
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_holders("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["error"] == _expected_retryable_error("fetching holders for 'AAPL'", exception)
+    assert data["details"]["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_holders_partial_failure(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test that partial failures in some sections still return available data."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.major_holders = _major_holders_df()
+    mock_ticker_obj.institutional_holders = _institutional_holders_df()
+    # Raise error when accessing mutualfund_holders
+    type(mock_ticker_obj).mutualfund_holders = PropertyMock(side_effect=RuntimeError("fetch failed"))
+    # Raise error when accessing insider_transactions
+    type(mock_ticker_obj).insider_transactions = PropertyMock(side_effect=RuntimeError("fetch failed"))
+    mock_ticker_obj.insider_purchases = _insider_purchases_df()
+    mock_ticker_obj.insider_roster_holders = _insider_roster_df()
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_holders("AAPL")
+    data = json.loads(result)
+
+    # Should still return the sections that succeeded
+    assert "major_holders" in data
+    assert "institutional_holders" in data
+    assert "insider_purchases" in data
+    assert "insider_roster" in data
+    # Failed sections should be absent
+    assert "mutualfund_holders" not in data
+    assert "insider_transactions" not in data


### PR DESCRIPTION
Adds a `yfinance_get_holders` tool for fetching ownership data such as major holders, institutional investors, mutual fund holders, and insider transactions.