### PR TITLE
[codex] Add Codex MCP config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+[mcp_servers.yfmcp]
+command = "uv"
+args    = ["run", "yfmcp"]
+cwd     = "."
+enabled = true

--- a/.gitignore
+++ b/.gitignore
@@ -134,8 +134,5 @@ dmypy.json
 # VS Code
 .vscode/
 
-# Codex CLI
-.codex
-
 # Claude code
 .claude/


### PR DESCRIPTION
## Summary

- Add a repo-local Codex MCP server config for `yfmcp`.
- Stop ignoring the `.codex` directory so the intended config can be committed.

## Validation

- `prek run -a`