### PR TITLE
[codex] Limit holder output rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Fetch major holders, institutional holders, mutual fund holders, and insider dat
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `symbol` | string | Yes | Stock ticker symbol (e.g. `AAPL`, `MSFT`) |
+| `max_rows` | number | No | Maximum rows returned per holder section. Default: `10`. Use `0` to return all rows |
 
 **Returns:** JSON object with:
 - **`major_holders`** — Aggregated breakdown where each row has an `index` label (e.g. `insidersPercentHeld`, `institutionsPercentHeld`, `institutionsFloatPercentHeld`, `institutionsCount`) and a `Value`
@@ -125,8 +126,9 @@ Fetch major holders, institutional holders, mutual fund holders, and insider dat
 - **`insider_transactions`** — Recent insider trades; records typically include fields such as `Shares`, `Value`, `Insider`, `Position`, `Transaction`, `Start Date`, `Ownership`
 - **`insider_purchases`** — Six-month summary where each row describes a category (Purchases, Sales, Net Shares, etc.); records typically include fields such as `Insider Purchases Last 6m`, `Shares`, `Trans`
 - **`insider_roster`** — Known insiders; records typically include fields such as `Name`, `Position`, `Shares Owned Directly`, `Most Recent Transaction`, `Latest Transaction Date`
+- **`_metadata`** — Row limit metadata with `max_rows` and per-section `total_rows`, `returned_rows`, and `truncated`
 
-Field names for holder-related datasets are provided by `yfinance` and may vary by ticker, data availability, and `yfinance` version.
+Holder sections are limited to 10 rows by default to keep responses concise. Pass `max_rows: 0` when you need the complete holder datasets. Field names for holder-related datasets are provided by `yfinance` and may vary by ticker, data availability, and `yfinance` version.
 
 ### `yfinance_get_option_dates`
 

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -1020,13 +1020,14 @@ async def _fetch_holder_section(
         if attr_name == "major_holders":
             df = df.reset_index()
 
-        records = df.to_dict(orient="records")
-        limited_records = records if max_rows == 0 else records[:max_rows]
+        total_rows = len(df)
+        limited_df = df if max_rows == 0 else df.head(max_rows)
+        limited_records = limited_df.to_dict(orient="records")
         result[result_key] = limited_records
         section_metadata[result_key] = {
-            "total_rows": len(records),
+            "total_rows": total_rows,
             "returned_rows": len(limited_records),
-            "truncated": len(limited_records) < len(records),
+            "truncated": len(limited_records) < total_rows,
         }
 
 

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -1005,7 +1005,9 @@ async def _fetch_holder_section(
     attr_name: str,
     result_key: str,
     result: dict[str, Any],
+    section_metadata: dict[str, dict[str, int | bool]],
     fetch_errors: list[Exception],
+    max_rows: int,
 ) -> None:
     """Fetch a single holder data section, adding successful data to result and failures to fetch_errors."""
     try:
@@ -1017,7 +1019,15 @@ async def _fetch_holder_section(
     if df is not None and not df.empty:
         if attr_name == "major_holders":
             df = df.reset_index()
-        result[result_key] = df.to_dict(orient="records")
+
+        records = df.to_dict(orient="records")
+        limited_records = records if max_rows == 0 else records[:max_rows]
+        result[result_key] = limited_records
+        section_metadata[result_key] = {
+            "total_rows": len(records),
+            "returned_rows": len(limited_records),
+            "truncated": len(limited_records) < len(records),
+        }
 
 
 @mcp.tool(
@@ -1031,6 +1041,10 @@ async def _fetch_holder_section(
 )
 async def get_holders(
     symbol: Annotated[str, Field(description="Stock ticker symbol (e.g., 'AAPL', 'GOOGL', 'MSFT')")],
+    max_rows: Annotated[
+        int,
+        Field(description="Maximum rows returned per holder section. Use 0 to return all rows."),
+    ] = 10,
 ) -> str:
     """Fetch major holders, institutional holders, mutual fund holders, and insider data.
 
@@ -1047,6 +1061,13 @@ async def get_holders(
 
     Use this to analyze ownership concentration, insider activity, and institutional interest.
     """
+    if max_rows < 0:
+        return create_error_response(
+            "max_rows must be greater than or equal to 0.",
+            error_code="INVALID_PARAMS",
+            details={"max_rows": max_rows},
+        )
+
     try:
         ticker = await asyncio.to_thread(yf.Ticker, symbol)
     except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
@@ -1059,13 +1080,54 @@ async def get_holders(
         )
 
     result: dict[str, Any] = {}
+    section_metadata: dict[str, dict[str, int | bool]] = {}
     fetch_errors: list[Exception] = []
-    await _fetch_holder_section(symbol, ticker, "major_holders", "major_holders", result, fetch_errors)
-    await _fetch_holder_section(symbol, ticker, "institutional_holders", "institutional_holders", result, fetch_errors)
-    await _fetch_holder_section(symbol, ticker, "mutualfund_holders", "mutualfund_holders", result, fetch_errors)
-    await _fetch_holder_section(symbol, ticker, "insider_transactions", "insider_transactions", result, fetch_errors)
-    await _fetch_holder_section(symbol, ticker, "insider_purchases", "insider_purchases", result, fetch_errors)
-    await _fetch_holder_section(symbol, ticker, "insider_roster_holders", "insider_roster", result, fetch_errors)
+    await _fetch_holder_section(
+        symbol, ticker, "major_holders", "major_holders", result, section_metadata, fetch_errors, max_rows
+    )
+    await _fetch_holder_section(
+        symbol,
+        ticker,
+        "institutional_holders",
+        "institutional_holders",
+        result,
+        section_metadata,
+        fetch_errors,
+        max_rows,
+    )
+    await _fetch_holder_section(
+        symbol,
+        ticker,
+        "mutualfund_holders",
+        "mutualfund_holders",
+        result,
+        section_metadata,
+        fetch_errors,
+        max_rows,
+    )
+    await _fetch_holder_section(
+        symbol,
+        ticker,
+        "insider_transactions",
+        "insider_transactions",
+        result,
+        section_metadata,
+        fetch_errors,
+        max_rows,
+    )
+    await _fetch_holder_section(
+        symbol, ticker, "insider_purchases", "insider_purchases", result, section_metadata, fetch_errors, max_rows
+    )
+    await _fetch_holder_section(
+        symbol,
+        ticker,
+        "insider_roster_holders",
+        "insider_roster",
+        result,
+        section_metadata,
+        fetch_errors,
+        max_rows,
+    )
 
     if not result:
         retryable_exceptions = [exc for exc in fetch_errors if _is_retryable_yfinance_error(exc)]
@@ -1082,6 +1144,7 @@ async def get_holders(
             details={"symbol": symbol},
         )
 
+    result["_metadata"] = {"max_rows": max_rows, "sections": section_metadata}
     return dump_json(result)
 
 

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -953,6 +953,18 @@ def _insider_transactions_df() -> pd.DataFrame:
     )
 
 
+def _many_insider_transactions_df(row_count: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Shares": list(range(row_count)),
+            "Value": [share * 100 for share in range(row_count)],
+            "Start Date": ["2025-12-01"] * row_count,
+            "Transaction": ["Sale"] * row_count,
+            "Insider": [f"Insider {index}" for index in range(row_count)],
+        }
+    )
+
+
 def _insider_purchases_df() -> pd.DataFrame:
     return pd.DataFrame(
         {
@@ -995,6 +1007,7 @@ async def test_get_holders_success_all_sections(mock_to_thread: AsyncMock, mock_
     assert "insider_transactions" in data
     assert "insider_purchases" in data
     assert "insider_roster" in data
+    assert "_metadata" in data
 
     assert data["major_holders"][0] == {"index": "insidersPercentHeld", "Value": 0.0015}
     assert data["major_holders"][1] == {"index": "institutionsPercentHeld", "Value": 0.65}
@@ -1005,6 +1018,78 @@ async def test_get_holders_success_all_sections(mock_to_thread: AsyncMock, mock_
 
     # Spot check insider roster
     assert data["insider_roster"][0]["Name"] == "COOK TIMOTHY D"
+
+    assert data["_metadata"]["max_rows"] == 10
+    assert data["_metadata"]["sections"]["insider_transactions"] == {
+        "total_rows": 2,
+        "returned_rows": 2,
+        "truncated": False,
+    }
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_holders_limits_rows_by_default(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test holder sections are truncated to the default max_rows."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.major_holders = _major_holders_df()
+    mock_ticker_obj.institutional_holders = _institutional_holders_df()
+    mock_ticker_obj.mutualfund_holders = _mutualfund_holders_df()
+    mock_ticker_obj.insider_transactions = _many_insider_transactions_df(12)
+    mock_ticker_obj.insider_purchases = _insider_purchases_df()
+    mock_ticker_obj.insider_roster_holders = _insider_roster_df()
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_holders("AAPL")
+    data = json.loads(result)
+
+    assert len(data["insider_transactions"]) == 10
+    assert data["insider_transactions"][0]["Insider"] == "Insider 0"
+    assert data["insider_transactions"][-1]["Insider"] == "Insider 9"
+    assert data["_metadata"]["sections"]["insider_transactions"] == {
+        "total_rows": 12,
+        "returned_rows": 10,
+        "truncated": True,
+    }
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_holders_max_rows_zero_returns_all_rows(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test max_rows=0 disables row limits."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.major_holders = _major_holders_df()
+    mock_ticker_obj.institutional_holders = _institutional_holders_df()
+    mock_ticker_obj.mutualfund_holders = _mutualfund_holders_df()
+    mock_ticker_obj.insider_transactions = _many_insider_transactions_df(12)
+    mock_ticker_obj.insider_purchases = _insider_purchases_df()
+    mock_ticker_obj.insider_roster_holders = _insider_roster_df()
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_holders("AAPL", max_rows=0)
+    data = json.loads(result)
+
+    assert len(data["insider_transactions"]) == 12
+    assert data["_metadata"]["max_rows"] == 0
+    assert data["_metadata"]["sections"]["insider_transactions"] == {
+        "total_rows": 12,
+        "returned_rows": 12,
+        "truncated": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_holders_rejects_negative_max_rows() -> None:
+    """Test max_rows must be non-negative."""
+    result = await get_holders("AAPL", max_rows=-1)
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"]["max_rows"] == -1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a `max_rows` parameter to `yfinance_get_holders`, defaulting to 10 rows per holder section.
- Add `_metadata` with per-section row counts and truncation status.
- Document the new row limit behavior and cover default, unlimited, and invalid parameter cases in unit tests.

## Validation

- `uv run pytest tests/test_server_unit.py -k holders`
- `uv run ruff check .`
- `uv run ty check src tests`
- `uv run pytest`
- `prek run -a`