### PR TITLE
Document Codex CLI testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ uv sync
 
 Replace `/path/to/yfinance-mcp` with the actual path to your cloned repository.
 
+### Testing with Codex CLI
+
+This repository includes `.codex/config.toml`, which registers the local `yfmcp` MCP server for Codex CLI using `uv run yfmcp`. After cloning the repository and running `uv sync`, open Codex CLI from the repository root and try prompts such as:
+
+```text
+Show VOO ticker info
+Show VOO price history for the last 5 days
+Find the ticker symbol for Toyota
+Get AAPL option expiration dates
+```
+
 ## Development
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- Add a README section for testing the repo-local Codex CLI MCP configuration
- Use text-visible prompt examples that exercise ticker info, price history, symbol search, and option dates

## Validation
- git diff --check -- README.md
- Manually exercised MCP prompts, including VOO ticker info, VOO 5-day price history, Toyota ticker search, and AAPL option dates