### PR TITLE
Add prepost option to price history

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Fetch historical price data and optionally generate technical analysis charts.
 | `period` | string | No | Time range — `1d`, `5d`, `1mo`, `3mo`, `6mo`, `1y`, `2y`, `5y`, `10y`, `ytd`, `max` (default: `1mo`) |
 | `interval` | string | No | Data granularity — `1m`, `2m`, `5m`, `15m`, `30m`, `60m`, `90m`, `1h`, `1d`, `5d`, `1wk`, `1mo`, `3mo` (default: `1d`) |
 | `chart_type` | string | No | Chart to generate (omit for tabular data) |
+| `prepost` | boolean | No | Include pre-market and post-market data when available (default: `false`; useful with intraday requests like `period="1d"`, `interval="1m"`) |
 
 **Chart types:**
 

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -615,6 +615,10 @@ async def get_price_history(
             )
         ),
     ] = None,
+    prepost: Annotated[
+        bool,
+        Field(description="Include pre-market and post-market data when available"),
+    ] = False,
 ) -> str | ImageContent:
     """Fetch historical price data and optionally generate technical analysis charts.
 
@@ -633,6 +637,8 @@ async def get_price_history(
     - 'vwap': Price with Volume Weighted Average Price overlay
     - 'volume_profile': Volume distribution by price level
 
+    Set prepost=True to include pre-market and post-market data when available.
+
     Note: Not all period/interval combinations are valid. Minute intervals (1m, 5m, etc.)
     only work with short periods (1d, 5d).
     """
@@ -642,13 +648,14 @@ async def get_price_history(
             ticker.history,
             period=period,
             interval=interval,
+            prepost=prepost,
             rounding=True,
         )
     except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
         return _create_retryable_error_response(
             f"fetching price history for '{symbol}'",
             exc,
-            {"symbol": symbol, "period": period, "interval": interval},
+            {"symbol": symbol, "period": period, "interval": interval, "prepost": prepost},
         )
     except Exception as exc:
         return create_error_response(
@@ -659,6 +666,7 @@ async def get_price_history(
                 "symbol": symbol,
                 "period": period,
                 "interval": interval,
+                "prepost": prepost,
                 "exception": str(exc),
             },
         )
@@ -670,7 +678,7 @@ async def get_price_history(
             "(e.g., '1m' interval requires '1d' or '5d' period), (3) Market holidays or insufficient history. "
             "Try a longer period or daily interval.",
             error_code="NO_DATA",
-            details={"symbol": symbol, "period": period, "interval": interval},
+            details={"symbol": symbol, "period": period, "interval": interval, "prepost": prepost},
         )
 
     if chart_type is None:

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -264,6 +264,72 @@ async def test_get_price_history_returns_markdown_table_when_chart_type_is_none(
     assert "Open" in result
     assert "Close" in result
     assert "|" in result
+    mock_ticker_obj.history.assert_called_once_with(period="1mo", interval="1d", prepost=False, rounding=True)
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_price_history_passes_prepost_to_yfinance(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test price history can request pre-market and post-market rows."""
+    df = pd.DataFrame(
+        {
+            "Open": [100.0],
+            "High": [110.0],
+            "Low": [95.0],
+            "Close": [105.0],
+            "Volume": [1_000_000],
+        },
+        index=[pd.Timestamp("2024-01-02")],
+    )
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.history.return_value = df
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_price_history("AAPL", "1d", "1m", None, True)
+
+    assert isinstance(result, str)
+    mock_ticker_obj.history.assert_called_once_with(period="1d", interval="1m", prepost=True, rounding=True)
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_price_history_no_data_includes_prepost_detail(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock
+) -> None:
+    """Test no-data errors include the prepost request value."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.history.return_value = pd.DataFrame()
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_price_history("AAPL", "1d", "1m", None, True)
+    data = json.loads(result)
+
+    assert data["error_code"] == "NO_DATA"
+    assert data["details"] == {"symbol": "AAPL", "period": "1d", "interval": "1m", "prepost": True}
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_price_history_api_error_includes_prepost_detail(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock
+) -> None:
+    """Test API errors include the prepost request value."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.history.side_effect = RuntimeError("history failed")
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_price_history("AAPL", "1d", "1m", None, True)
+    data = json.loads(result)
+
+    assert data["error_code"] == "API_ERROR"
+    assert data["details"]["prepost"] is True
+    assert data["details"]["exception"] == "history failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a `prepost` option to `yfinance_get_price_history` and forward it to `Ticker.history()`
- include `prepost` in price-history error details
- document the option and add unit coverage

Resolves #126

## Tests
- `uv run pytest -v tests/test_server_unit.py -k price_history`
- `uv run ruff check .`
- `uv run ty check src tests`
- `uv run pytest -v -s --cov=src tests`
- `prek run -a`