### PR TITLE
fix: convert em dash to hyphen in industry key for Yahoo Finance API

### DIFF
--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -400,6 +400,22 @@ async def get_top_companies(
     return dump_json(df.head(top_n).to_dict(orient="records"))
 
 
+def _industry_key(name: str) -> str:
+    """Convert human-readable industry name to Yahoo Finance API key format.
+
+    SECTOR_INDUSTY_MAPPING uses em dashes (—) and title case,
+    but the API expects lowercase with regular hyphens.
+    """
+    return (
+        name.lower()
+        .replace("& ", "")
+        .replace("- ", "")
+        .replace(", ", " ")
+        .replace("—", "-")
+        .replace(" ", "-")
+    )
+
+
 async def get_top_growth_companies(
     sector: Annotated[Sector, Field(description="Market sector (e.g., 'Technology', 'Healthcare')")],
     top_n: Annotated[int, Field(description="Number of top growth companies per industry", ge=1)],
@@ -423,7 +439,7 @@ async def get_top_growth_companies(
     results = []
     for industry_name in industries:
         try:
-            industry = await asyncio.to_thread(yf.Industry, industry_name)
+            industry = await asyncio.to_thread(yf.Industry, _industry_key(industry_name))
         except Exception as exc:
             logger.warning("Failed to load industry {}: {}", industry_name, exc)
             continue
@@ -472,7 +488,7 @@ async def get_top_performing_companies(
     results = []
     for industry_name in industries:
         try:
-            industry = await asyncio.to_thread(yf.Industry, industry_name)
+            industry = await asyncio.to_thread(yf.Industry, _industry_key(industry_name))
         except Exception as exc:
             logger.warning("Failed to load industry {}: {}", industry_name, exc)
             continue


### PR DESCRIPTION
## Problem

The `SECTOR_INDUSTY_MAPPING` in yfinance uses em dashes (—) in some industry names like `Software—Infrastructure`, but the Yahoo Finance API expects lowercase keys with regular hyphens like `software-infrastructure`.

The current code passes industry names directly to `yf.Industry()`:

```python
industry = await asyncio.to_thread(yf.Industry, industry_name)
```

This fails with HTTP 404 for industries containing em dashes because the URL becomes:
```
https://query1.finance.yahoo.com/v1/finance/industries/software—infrastructure
```
instead of:
```
https://query1.finance.yahoo.com/v1/finance/industries/software-infrastructure
```

## Fix

Added a `_industry_key()` helper function that converts human-readable industry names to the format expected by the Yahoo Finance API:

- Lowercase the name
- Remove `& `, `- `, `, ` prefixes
- Convert em dashes to regular hyphens
- Replace spaces with hyphens

Used this helper in both `get_top_growth_companies` and `get_top_performing_companies`.

## Example

| Input (from SECTOR_INDUSTY_MAPPING) | Output (API key) |
|---|---|
| `Software—Infrastructure` | `software-infrastructure` |
| `Semiconductors & Semiconductor Equipment` | `semiconductors-semiconductor-equipment` |
| `Health Care Providers & Services` | `health-care-providers-services` |