### PR TITLE
fix: normalize yfinance domain keys

### DIFF
--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -310,7 +310,7 @@ async def get_top_etfs(
     - name: Full ETF name
     """
     try:
-        s = await asyncio.to_thread(yf.Sector, sector)
+        s = await asyncio.to_thread(yf.Sector, _sector_key(sector))
         etfs = await asyncio.to_thread(lambda: s.top_etfs)
     except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
         return _create_retryable_error_response(f"fetching top ETFs for '{sector}'", exc, {"sector": sector})
@@ -343,7 +343,7 @@ async def get_top_mutual_funds(
     - name: Full fund name
     """
     try:
-        s = await asyncio.to_thread(yf.Sector, sector)
+        s = await asyncio.to_thread(yf.Sector, _sector_key(sector))
         funds = await asyncio.to_thread(lambda: s.top_mutual_funds)
     except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
         return _create_retryable_error_response(
@@ -379,7 +379,7 @@ async def get_top_companies(
     Typically includes company identifiers, market metrics, and analyst information.
     """
     try:
-        s = await asyncio.to_thread(yf.Sector, sector)
+        s = await asyncio.to_thread(yf.Sector, _sector_key(sector))
         df = await asyncio.to_thread(lambda: s.top_companies)
     except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
         return _create_retryable_error_response(f"fetching top companies for '{sector}'", exc, {"sector": sector})
@@ -398,6 +398,11 @@ async def get_top_companies(
         )
 
     return dump_json(df.head(top_n).to_dict(orient="records"))
+
+
+def _sector_key(name: str) -> str:
+    """Convert human-readable sector name to Yahoo Finance API key format."""
+    return name.lower().replace(" ", "-")
 
 
 def _industry_key(name: str) -> str:

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -406,14 +406,7 @@ def _industry_key(name: str) -> str:
     SECTOR_INDUSTY_MAPPING uses em dashes (—) and title case,
     but the API expects lowercase with regular hyphens.
     """
-    return (
-        name.lower()
-        .replace("& ", "")
-        .replace("- ", "")
-        .replace(", ", " ")
-        .replace("—", "-")
-        .replace(" ", "-")
-    )
+    return name.lower().replace("& ", "").replace("- ", "").replace(", ", " ").replace("—", "-").replace(" ", "-")
 
 
 async def get_top_growth_companies(

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import PropertyMock
+from unittest.mock import call
 from unittest.mock import patch
 
 import pandas as pd
@@ -11,6 +12,7 @@ import pytest
 from yfinance.exceptions import YFRateLimitError
 
 from yfmcp.server import _build_financials_response
+from yfmcp.server import _industry_key
 from yfmcp.server import get_financials
 from yfmcp.server import get_holders
 from yfmcp.server import get_option_chain
@@ -42,6 +44,20 @@ def _expected_retryable_error(action: str, exception: Exception) -> str:
     if isinstance(exception, YFRateLimitError):
         return f"Rate limit reached while {action}. Try again later."
     return f"Temporary network issue while {action}. Try again later."
+
+
+@pytest.mark.parametrize(
+    ("industry_name", "expected_key"),
+    [
+        ("Communication Equipment", "communication-equipment"),
+        ("Electronics & Computer Distribution", "electronics-computer-distribution"),
+        ("Banks—Diversified", "banks-diversified"),
+        ("Furnishings, Fixtures & Appliances", "furnishings-fixtures-appliances"),
+    ],
+)
+def test_industry_key_normalizes_yfinance_mapping_names(industry_name: str, expected_key: str) -> None:
+    """Test industry names from yfinance constants are converted to API keys."""
+    assert _industry_key(industry_name) == expected_key
 
 
 class _FinancialsReadErrorTicker:
@@ -507,6 +523,48 @@ async def test_get_top_growth_companies_success(mock_to_thread: AsyncMock, mock_
     assert len(data) > 0
     assert "industry" in data[0]
     assert "top_growth_companies" in data[0]
+
+
+@pytest.mark.asyncio
+@patch(
+    "yfmcp.server.SECTOR_INDUSTY_MAPPING",
+    {"Technology": ["Communication Equipment", "Electronics & Computer Distribution", "Banks—Diversified"]},
+)
+@patch("yfmcp.server.yf.Industry")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_top_growth_companies_loads_industries_by_api_key(
+    mock_to_thread: AsyncMock,
+    mock_industry: MagicMock,
+) -> None:
+    """Test growth company retrieval passes normalized keys to yfinance."""
+    mock_industry_obj = MagicMock()
+    mock_industry_obj.top_growth_companies = pd.DataFrame(
+        {
+            "symbol": ["NVDA"],
+            "name": ["NVIDIA"],
+            "growth": [50.0],
+        }
+    )
+
+    async def mock_thread_func(func, *args):
+        if callable(func):
+            return func(*args)
+        return mock_industry_obj
+
+    mock_to_thread.side_effect = mock_thread_func
+    mock_industry.return_value = mock_industry_obj
+
+    result = await get_top_growth_companies("Technology", 1)
+    data = json.loads(result)
+
+    assert isinstance(data, list)
+    mock_industry.assert_has_calls(
+        [
+            call("communication-equipment"),
+            call("electronics-computer-distribution"),
+            call("banks-diversified"),
+        ]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -13,6 +13,7 @@ from yfinance.exceptions import YFRateLimitError
 
 from yfmcp.server import _build_financials_response
 from yfmcp.server import _industry_key
+from yfmcp.server import _sector_key
 from yfmcp.server import get_financials
 from yfmcp.server import get_holders
 from yfmcp.server import get_option_chain
@@ -44,6 +45,20 @@ def _expected_retryable_error(action: str, exception: Exception) -> str:
     if isinstance(exception, YFRateLimitError):
         return f"Rate limit reached while {action}. Try again later."
     return f"Temporary network issue while {action}. Try again later."
+
+
+@pytest.mark.parametrize(
+    ("sector_name", "expected_key"),
+    [
+        ("Technology", "technology"),
+        ("Financial Services", "financial-services"),
+        ("Communication Services", "communication-services"),
+        ("Basic Materials", "basic-materials"),
+    ],
+)
+def test_sector_key_normalizes_yfinance_mapping_names(sector_name: str, expected_key: str) -> None:
+    """Test sector names from yfinance constants are converted to API keys."""
+    assert _sector_key(sector_name) == expected_key
 
 
 @pytest.mark.parametrize(
@@ -373,6 +388,7 @@ async def test_get_top_etfs_success(mock_to_thread: AsyncMock, mock_sector: Magi
     assert len(data) == 2
     assert data[0]["symbol"] == "SPY"
     assert data[0]["name"] == "SPDR S&P 500 ETF"
+    mock_sector.assert_called_once_with("technology")
 
 
 @pytest.mark.asyncio
@@ -436,6 +452,7 @@ async def test_get_top_mutual_funds_success(mock_to_thread: AsyncMock, mock_sect
 
     assert isinstance(data, list)
     assert len(data) == 2
+    mock_sector.assert_called_once_with("technology")
 
 
 @pytest.mark.asyncio
@@ -467,6 +484,7 @@ async def test_get_top_companies_success(mock_to_thread: AsyncMock, mock_sector:
     assert isinstance(data, list)
     assert len(data) == 3
     assert data[0]["symbol"] == "AAPL"
+    mock_sector.assert_called_once_with("technology")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add regression coverage for industry key normalization
- Normalize sector display names before constructing yfinance Sector objects
- Cover sector key conversion for ETF, mutual fund, and company ranking tools

## Validation
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check src tests
- uv lock --check

Note: prek run -a previously stalled while installing hooks, so the equivalent hook commands were run individually.