### PR TITLE
Add Yahoo Finance screener tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,61 @@ Get top-ranked financial entities within a market sector.
 
 `Basic Materials`, `Communication Services`, `Consumer Cyclical`, `Consumer Defensive`, `Energy`, `Financial Services`, `Healthcare`, `Industrials`, `Real Estate`, `Technology`, `Utilities`
 
+### `yfinance_screen`
+
+Run Yahoo Finance screeners using either predefined screener keys or custom query trees.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string/object | Yes | For `query_type="predefined"`: screener key such as `"day_gainers"`. For `query_type="equity"` or `"fund"`: custom query tree with `{operator, operands}` nodes |
+| `query_type` | string | No | `"predefined"` (default), `"equity"`, or `"fund"` |
+| `offset` | number | No | Result offset |
+| `size` | number | No | Rows for custom queries; Yahoo maximum is `250` |
+| `count` | number | No | Rows for predefined queries; Yahoo maximum is `250` |
+| `sort_field` | string | No | Sort field, for example `"percentchange"` |
+| `sort_asc` | boolean | No | Sort ascending if `true`, descending if `false` |
+| `user_id` | string | No | Optional Yahoo user identifier |
+| `user_id_type` | string | No | Optional Yahoo user ID type, commonly `"guid"` |
+
+**Returns:** JSON screener response from Yahoo Finance, typically including quote rows and metadata.
+
+Custom equity screener example:
+
+```json
+{
+  "query_type": "equity",
+  "query": {
+    "operator": "and",
+    "operands": [
+      { "operator": "gt", "operands": ["percentchange", 3] },
+      { "operator": "eq", "operands": ["region", "us"] },
+      { "operator": "gte", "operands": ["intradayprice", 5] },
+      { "operator": "gt", "operands": ["dayvolume", 500000] }
+    ]
+  },
+  "sort_field": "percentchange",
+  "sort_asc": false,
+  "size": 50
+}
+```
+
+### `yfinance_screen_gappers`
+
+Run a purpose-built custom screener for opening-session bullish gappers.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `min_percent_change` | number | No | Minimum percent gap/change from prior close (default: `3.0`) |
+| `min_price` | number | No | Minimum intraday price (default: `5.0`) |
+| `min_volume` | number | No | Minimum day volume (default: `500000`) |
+| `min_market_cap` | number | No | Minimum intraday market cap in USD (default: `2000000000`) |
+| `region` | string | No | Yahoo region code (default: `"us"`) |
+| `size` | number | No | Number of results (default: `50`, max: `250`) |
+| `offset` | number | No | Result offset for pagination (default: `0`) |
+| `sort_asc` | boolean | No | Sort by `percentchange` ascending (`true`) or descending (`false`, default) |
+
+**Returns:** JSON screener response from Yahoo Finance.
+
 ### `yfinance_get_price_history`
 
 Fetch historical price data and optionally generate technical analysis charts.

--- a/src/yfmcp/screener.py
+++ b/src/yfmcp/screener.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+
+from yfinance import EquityQuery
+from yfinance import FundQuery
+from yfinance.screener.query import Operator
+
+ScreenerQuery = EquityQuery | FundQuery
+
+LEAF_OPERATORS = {"eq", "is-in", "btwn", "gt", "lt", "gte", "lte"}
+LOGICAL_OPERATORS = {"and", "or"}
+
+
+def build_screener_query(query_type: str, query: dict[str, Any]) -> ScreenerQuery:
+    """Build a yfinance screener query object from a JSON-serializable query tree."""
+    match query_type.lower():
+        case "equity":
+            return _build_equity_node(query)
+        case "fund":
+            return _build_fund_node(query)
+        case _:
+            raise ValueError("query_type must be 'equity' or 'fund' for custom queries")
+
+
+def _validate_node_shape(node: dict[str, Any]) -> tuple[Operator, list[Any]]:
+    if not isinstance(node, dict):
+        raise ValueError("Each query node must be an object with 'operator' and 'operands'")
+
+    operator = node.get("operator")
+    operands = node.get("operands")
+
+    if not isinstance(operator, str) or not operator.strip():
+        raise ValueError("Each query node must include a non-empty string 'operator'")
+    if not isinstance(operands, list) or len(operands) == 0:
+        raise ValueError("Each query node must include a non-empty list 'operands'")
+
+    normalized_operator = operator.lower()
+    if normalized_operator not in LEAF_OPERATORS.union(LOGICAL_OPERATORS):
+        valid_operators = sorted(LEAF_OPERATORS.union(LOGICAL_OPERATORS))
+        raise ValueError(f"Unsupported operator '{operator.upper()}'. Valid operators: {', '.join(valid_operators)}")
+
+    return cast(Operator, normalized_operator), operands
+
+
+def _build_equity_node(node: dict[str, Any]) -> EquityQuery:
+    normalized_operator, operands = _validate_node_shape(node)
+
+    if normalized_operator in LOGICAL_OPERATORS:
+        nested_queries: list[EquityQuery] = []
+        for operand in operands:
+            if not isinstance(operand, dict):
+                raise ValueError(f"Operator '{normalized_operator.upper()}' requires nested query objects")
+            nested_queries.append(_build_equity_node(cast(dict[str, Any], operand)))
+        return EquityQuery(normalized_operator, cast(Any, nested_queries))
+
+    if normalized_operator in LEAF_OPERATORS:
+        if any(isinstance(operand, dict) for operand in operands):
+            raise ValueError(f"Operator '{normalized_operator.upper()}' does not accept nested query objects")
+        return EquityQuery(normalized_operator, operands)
+    raise ValueError(f"Unsupported operator '{normalized_operator.upper()}'")
+
+
+def _build_fund_node(node: dict[str, Any]) -> FundQuery:
+    normalized_operator, operands = _validate_node_shape(node)
+
+    if normalized_operator in LOGICAL_OPERATORS:
+        nested_queries: list[FundQuery] = []
+        for operand in operands:
+            if not isinstance(operand, dict):
+                raise ValueError(f"Operator '{normalized_operator.upper()}' requires nested query objects")
+            nested_queries.append(_build_fund_node(cast(dict[str, Any], operand)))
+        return FundQuery(normalized_operator, cast(Any, nested_queries))
+
+    if normalized_operator in LEAF_OPERATORS:
+        if any(isinstance(operand, dict) for operand in operands):
+            raise ValueError(f"Operator '{normalized_operator.upper()}' does not accept nested query objects")
+        return FundQuery(normalized_operator, operands)
+    raise ValueError(f"Unsupported operator '{normalized_operator.upper()}'")

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -467,7 +467,7 @@ async def screen_gappers(
             {"operator": "eq", "operands": ["region", region]},
             {"operator": "gte", "operands": ["intradaymarketcap", min_market_cap]},
             {"operator": "gte", "operands": ["intradayprice", min_price]},
-            {"operator": "gt", "operands": ["dayvolume", min_volume]},
+            {"operator": "gte", "operands": ["dayvolume", min_volume]},
         ],
     }
 

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -463,7 +463,7 @@ async def screen_gappers(
     query = {
         "operator": "and",
         "operands": [
-            {"operator": "gt", "operands": ["percentchange", min_percent_change]},
+            {"operator": "gte", "operands": ["percentchange", min_percent_change]},
             {"operator": "eq", "operands": ["region", region]},
             {"operator": "gte", "operands": ["intradaymarketcap", min_market_cap]},
             {"operator": "gte", "operands": ["intradayprice", min_price]},

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -343,6 +343,19 @@ async def screen(
     Supports predefined Yahoo screener keys and custom equity or fund query trees.
     """
     try:
+        if query_type == "predefined" and size is not None:
+            return create_error_response(
+                "For query_type='predefined', use count instead of size.",
+                error_code="INVALID_PARAMS",
+                details={"query_type": query_type, "invalid_parameter": "size", "expected_parameter": "count"},
+            )
+        if query_type in {"equity", "fund"} and count is not None:
+            return create_error_response(
+                "For query_type='equity' or 'fund', use size instead of count.",
+                error_code="INVALID_PARAMS",
+                details={"query_type": query_type, "invalid_parameter": "count", "expected_parameter": "size"},
+            )
+
         if query_type == "predefined":
             if not isinstance(query, str):
                 return create_error_response(
@@ -385,7 +398,7 @@ async def screen(
             userId=user_id,
             userIdType=user_id_type,
         )
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         return create_error_response(
             "Invalid screener query. Check operators, operands, and field values for the selected query_type.",
             error_code="INVALID_PARAMS",
@@ -415,7 +428,7 @@ async def screen(
 async def screen_gappers(
     min_percent_change: Annotated[
         float,
-        Field(description="Minimum percent change from prior close, for example 3.0 for +3%."),
+        Field(description="Minimum percent change from prior close, for example 3.0 for +3%.", ge=0),
     ] = 3.0,
     min_price: Annotated[
         float,
@@ -468,7 +481,7 @@ async def screen_gappers(
             sortField="percentchange",
             sortAsc=sort_asc,
         )
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         return create_error_response(
             "Invalid gappers screener parameters.",
             error_code="INVALID_PARAMS",

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -13,10 +13,12 @@ from yfinance.const import SECTOR_INDUSTY_MAPPING
 from yfinance.exceptions import YFRateLimitError
 
 from yfmcp.chart import generate_chart
+from yfmcp.screener import build_screener_query
 from yfmcp.types import ChartType
 from yfmcp.types import Interval
 from yfmcp.types import OptionChainType
 from yfmcp.types import Period
+from yfmcp.types import ScreenerQueryType
 from yfmcp.types import SearchType
 from yfmcp.types import Sector
 from yfmcp.types import TopType
@@ -297,6 +299,191 @@ async def search(
                 error_code="INVALID_PARAMS",
                 details={"search_type": search_type, "valid_options": ["all", "quotes", "news"]},
             )
+
+
+@mcp.tool(
+    name="yfinance_screen",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def screen(
+    query: Annotated[
+        str | dict[str, Any],
+        Field(
+            description=(
+                "Screener query. For query_type='predefined': string key like 'day_gainers'. "
+                "For query_type='equity' or 'fund': query tree object with {operator, operands} nodes."
+            )
+        ),
+    ],
+    query_type: Annotated[
+        ScreenerQueryType,
+        Field(description="Query mode: 'predefined', 'equity', or 'fund'."),
+    ] = "predefined",
+    offset: Annotated[int | None, Field(description="Result offset.", ge=0)] = None,
+    size: Annotated[
+        int | None,
+        Field(description="Rows to return for custom queries. Yahoo maximum is 250.", ge=1, le=250),
+    ] = None,
+    count: Annotated[
+        int | None,
+        Field(description="Rows to return for predefined queries. Yahoo maximum is 250.", ge=1, le=250),
+    ] = None,
+    sort_field: Annotated[str | None, Field(description="Sort field, for example 'percentchange'.")] = None,
+    sort_asc: Annotated[bool | None, Field(description="Sort ascending if true, descending if false.")] = None,
+    user_id: Annotated[str | None, Field(description="Optional Yahoo user id.")] = None,
+    user_id_type: Annotated[str | None, Field(description="Optional Yahoo user id type, commonly 'guid'.")] = None,
+) -> str:
+    """Run a Yahoo Finance screener query.
+
+    Supports predefined Yahoo screener keys and custom equity or fund query trees.
+    """
+    try:
+        if query_type == "predefined":
+            if not isinstance(query, str):
+                return create_error_response(
+                    "For query_type='predefined', query must be a string screener key.",
+                    error_code="INVALID_PARAMS",
+                    details={"query_type": query_type, "expected_query_type": "string"},
+                )
+
+            predefined = getattr(yf, "PREDEFINED_SCREENER_QUERIES", {})
+            if query not in predefined:
+                return create_error_response(
+                    f"Unknown predefined screener '{query}'.",
+                    error_code="INVALID_PARAMS",
+                    details={
+                        "query": query,
+                        "query_type": query_type,
+                        "valid_predefined_queries": sorted(predefined.keys()),
+                    },
+                )
+
+            resolved_query: str | Any = query
+        else:
+            if not isinstance(query, dict):
+                return create_error_response(
+                    "For query_type='equity' or 'fund', query must be an object with 'operator' and 'operands'.",
+                    error_code="INVALID_PARAMS",
+                    details={"query_type": query_type, "expected_query_type": "object"},
+                )
+
+            resolved_query = build_screener_query(query_type=query_type, query=query)
+
+        result = await asyncio.to_thread(
+            yf.screen,
+            resolved_query,
+            offset=offset,
+            size=size,
+            count=count,
+            sortField=sort_field,
+            sortAsc=sort_asc,
+            userId=user_id,
+            userIdType=user_id_type,
+        )
+    except ValueError as exc:
+        return create_error_response(
+            "Invalid screener query. Check operators, operands, and field values for the selected query_type.",
+            error_code="INVALID_PARAMS",
+            details={"query_type": query_type, "exception": str(exc)},
+        )
+    except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
+        return _create_retryable_error_response("running screener query", exc, {"query_type": query_type})
+    except Exception as exc:
+        return create_error_response(
+            "Failed to run screener query.",
+            error_code="API_ERROR",
+            details={"query_type": query_type, "exception": str(exc)},
+        )
+
+    return dump_json(result)
+
+
+@mcp.tool(
+    name="yfinance_screen_gappers",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def screen_gappers(
+    min_percent_change: Annotated[
+        float,
+        Field(description="Minimum percent change from prior close, for example 3.0 for +3%."),
+    ] = 3.0,
+    min_price: Annotated[
+        float,
+        Field(description="Minimum current intraday price.", ge=0),
+    ] = 5.0,
+    min_volume: Annotated[
+        int,
+        Field(description="Minimum intraday trading volume.", ge=0),
+    ] = 500000,
+    min_market_cap: Annotated[
+        int,
+        Field(description="Minimum intraday market cap in USD.", ge=0),
+    ] = 2000000000,
+    region: Annotated[
+        str,
+        Field(description="Yahoo screener region code, for example 'us'."),
+    ] = "us",
+    size: Annotated[
+        int,
+        Field(description="Rows to return. Yahoo maximum is 250.", ge=1, le=250),
+    ] = 50,
+    offset: Annotated[
+        int,
+        Field(description="Result offset for pagination.", ge=0),
+    ] = 0,
+    sort_asc: Annotated[
+        bool,
+        Field(description="Sort by percentchange ascending if true, descending if false."),
+    ] = False,
+) -> str:
+    """Run a custom equity screener tuned for opening-session stock gappers."""
+    query = {
+        "operator": "and",
+        "operands": [
+            {"operator": "gt", "operands": ["percentchange", min_percent_change]},
+            {"operator": "eq", "operands": ["region", region]},
+            {"operator": "gte", "operands": ["intradaymarketcap", min_market_cap]},
+            {"operator": "gte", "operands": ["intradayprice", min_price]},
+            {"operator": "gt", "operands": ["dayvolume", min_volume]},
+        ],
+    }
+
+    try:
+        resolved_query = build_screener_query(query_type="equity", query=query)
+        result = await asyncio.to_thread(
+            yf.screen,
+            resolved_query,
+            offset=offset,
+            size=size,
+            sortField="percentchange",
+            sortAsc=sort_asc,
+        )
+    except ValueError as exc:
+        return create_error_response(
+            "Invalid gappers screener parameters.",
+            error_code="INVALID_PARAMS",
+            details={"exception": str(exc)},
+        )
+    except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
+        return _create_retryable_error_response("running gappers screener", exc, {})
+    except Exception as exc:
+        return create_error_response(
+            "Failed to run gappers screener.",
+            error_code="API_ERROR",
+            details={"exception": str(exc)},
+        )
+
+    return dump_json(result)
 
 
 async def get_top_etfs(

--- a/src/yfmcp/types.py
+++ b/src/yfmcp/types.py
@@ -79,6 +79,12 @@ ChartType = Literal[
     "volume_profile",
 ]
 
+ScreenerQueryType = Literal[
+    "predefined",
+    "equity",
+    "fund",
+]
+
 OptionChainType = Literal[
     "calls",
     "puts",

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,0 +1,54 @@
+import pytest
+from yfinance import EquityQuery
+from yfinance import FundQuery
+
+from yfmcp.screener import build_screener_query
+
+
+def test_build_equity_query_success() -> None:
+    """Test JSON-style equity query trees build yfinance EquityQuery objects."""
+    query = {
+        "operator": "and",
+        "operands": [
+            {"operator": "gt", "operands": ["percentchange", 3]},
+            {"operator": "eq", "operands": ["region", "us"]},
+        ],
+    }
+
+    result = build_screener_query("equity", query)
+
+    assert isinstance(result, EquityQuery)
+    assert result.operator == "AND"
+    assert len(result.operands) == 2
+
+
+def test_build_fund_query_success() -> None:
+    """Test JSON-style fund query trees build yfinance FundQuery objects."""
+    query = {
+        "operator": "and",
+        "operands": [
+            {"operator": "eq", "operands": ["categoryname", "Large Growth"]},
+            {"operator": "eq", "operands": ["exchange", "NAS"]},
+        ],
+    }
+
+    result = build_screener_query("fund", query)
+
+    assert isinstance(result, FundQuery)
+    assert result.operator == "AND"
+
+
+def test_build_query_invalid_operator() -> None:
+    """Test unsupported operators are rejected."""
+    query = {"operator": "contains", "operands": ["region", "us"]}
+
+    with pytest.raises(ValueError, match="Unsupported operator"):
+        build_screener_query("equity", query)
+
+
+def test_build_query_invalid_type() -> None:
+    """Test custom query builder only accepts equity and fund query types."""
+    query = {"operator": "eq", "operands": ["region", "us"]}
+
+    with pytest.raises(ValueError, match="query_type must be 'equity' or 'fund'"):
+        build_screener_query("predefined", query)

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -24,6 +24,8 @@ from yfmcp.server import get_top_etfs
 from yfmcp.server import get_top_growth_companies
 from yfmcp.server import get_top_mutual_funds
 from yfmcp.server import get_top_performing_companies
+from yfmcp.server import screen
+from yfmcp.server import screen_gappers
 
 
 def _financials_df(rows: dict[str, list[int]]) -> pd.DataFrame:
@@ -1374,3 +1376,112 @@ async def test_get_holders_all_sections_retryable_failure(
     assert data["error_code"] == "NETWORK_ERROR"
     assert data["error"] == _expected_retryable_error("fetching holders for 'AAPL'", exception)
     assert data["details"]["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_predefined_success(mock_to_thread: AsyncMock) -> None:
+    """Test predefined Yahoo Finance screener execution."""
+    mock_to_thread.return_value = {"quotes": [{"symbol": "AAPL"}], "total": 1}
+
+    result = await screen("day_gainers", query_type="predefined", count=10)
+    data = json.loads(result)
+
+    assert data["quotes"] == [{"symbol": "AAPL"}]
+    assert data["total"] == 1
+    mock_to_thread.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_screen_predefined_invalid_query_type_payload() -> None:
+    """Test predefined screeners require a string screener key."""
+    result = await screen({"operator": "eq", "operands": ["region", "us"]}, query_type="predefined")
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"]["expected_query_type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_screen_predefined_unknown_key() -> None:
+    """Test unknown predefined screener keys return valid options."""
+    result = await screen("not_a_real_screener", query_type="predefined")
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"]["query"] == "not_a_real_screener"
+    assert "valid_predefined_queries" in data["details"]
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_custom_equity_success(mock_to_thread: AsyncMock) -> None:
+    """Test custom equity screener query execution."""
+    mock_to_thread.return_value = {"quotes": [{"symbol": "TSLA"}], "total": 1}
+    query = {
+        "operator": "and",
+        "operands": [
+            {"operator": "gt", "operands": ["percentchange", 3]},
+            {"operator": "eq", "operands": ["region", "us"]},
+        ],
+    }
+
+    result = await screen(query, query_type="equity", size=25, sort_field="percentchange", sort_asc=False)
+    data = json.loads(result)
+
+    assert data["quotes"][0]["symbol"] == "TSLA"
+    mock_to_thread.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_custom_invalid_operator_returns_invalid_params(mock_to_thread: AsyncMock) -> None:
+    """Test invalid custom query operators are rejected before the API call."""
+    query = {
+        "operator": "and",
+        "operands": [
+            {"operator": "contains", "operands": ["region", "us"]},
+            {"operator": "eq", "operands": ["region", "us"]},
+        ],
+    }
+
+    result = await screen(query, query_type="equity")
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    mock_to_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_gappers_success(mock_to_thread: AsyncMock) -> None:
+    """Test the gappers convenience screener."""
+    mock_to_thread.return_value = {"quotes": [{"symbol": "IONQ"}], "total": 1}
+
+    result = await screen_gappers(
+        min_percent_change=4.0,
+        min_price=10.0,
+        min_volume=1_000_000,
+        min_market_cap=3_000_000_000,
+        region="us",
+        size=25,
+        offset=0,
+        sort_asc=False,
+    )
+    data = json.loads(result)
+
+    assert data["quotes"][0]["symbol"] == "IONQ"
+    mock_to_thread.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_gappers_api_error(mock_to_thread: AsyncMock) -> None:
+    """Test gappers API failures return structured errors."""
+    mock_to_thread.side_effect = RuntimeError("Yahoo failed")
+
+    result = await screen_gappers()
+    data = json.loads(result)
+
+    assert data["error_code"] == "API_ERROR"
+    assert data["details"]["exception"] == "Yahoo failed"

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -1415,6 +1415,19 @@ async def test_screen_predefined_unknown_key() -> None:
 
 @pytest.mark.asyncio
 @patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_predefined_rejects_size_parameter(mock_to_thread: AsyncMock) -> None:
+    """Test predefined screeners reject the custom-query size parameter."""
+    result = await screen("day_gainers", query_type="predefined", size=10)
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"]["invalid_parameter"] == "size"
+    assert data["details"]["expected_parameter"] == "count"
+    mock_to_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.asyncio.to_thread")
 async def test_screen_custom_equity_success(mock_to_thread: AsyncMock) -> None:
     """Test custom equity screener query execution."""
     mock_to_thread.return_value = {"quotes": [{"symbol": "TSLA"}], "total": 1}
@@ -1435,6 +1448,21 @@ async def test_screen_custom_equity_success(mock_to_thread: AsyncMock) -> None:
 
 @pytest.mark.asyncio
 @patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_custom_rejects_count_parameter(mock_to_thread: AsyncMock) -> None:
+    """Test custom screeners reject the predefined-query count parameter."""
+    query = {"operator": "eq", "operands": ["region", "us"]}
+
+    result = await screen(query, query_type="equity", count=10)
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"]["invalid_parameter"] == "count"
+    assert data["details"]["expected_parameter"] == "size"
+    mock_to_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.asyncio.to_thread")
 async def test_screen_custom_invalid_operator_returns_invalid_params(mock_to_thread: AsyncMock) -> None:
     """Test invalid custom query operators are rejected before the API call."""
     query = {
@@ -1449,6 +1477,25 @@ async def test_screen_custom_invalid_operator_returns_invalid_params(mock_to_thr
     data = json.loads(result)
 
     assert data["error_code"] == "INVALID_PARAMS"
+    mock_to_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.build_screener_query")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_custom_type_error_returns_invalid_params(
+    mock_to_thread: AsyncMock, mock_build_screener_query: MagicMock
+) -> None:
+    """Test yfinance query shape type errors are treated as parameter errors."""
+    mock_build_screener_query.side_effect = TypeError("bad operand shape")
+    query = {"operator": "eq", "operands": ["percentchange", "not numeric"]}
+
+    result = await screen(query, query_type="equity")
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"]["query_type"] == "equity"
+    assert data["details"]["exception"] == "bad operand shape"
     mock_to_thread.assert_not_called()
 
 
@@ -1472,6 +1519,23 @@ async def test_screen_gappers_success(mock_to_thread: AsyncMock) -> None:
 
     assert data["quotes"][0]["symbol"] == "IONQ"
     mock_to_thread.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.build_screener_query")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_gappers_type_error_returns_invalid_params(
+    mock_to_thread: AsyncMock, mock_build_screener_query: MagicMock
+) -> None:
+    """Test gappers query validation type errors are treated as parameter errors."""
+    mock_build_screener_query.side_effect = TypeError("bad gapper operand")
+
+    result = await screen_gappers()
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"]["exception"] == "bad gapper operand"
+    mock_to_thread.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `yfinance_screen` and `yfinance_screen_gappers` MCP tools
- support predefined screener keys and custom equity/fund query trees
- return `INVALID_PARAMS` for invalid screener parameter combinations and query type errors
- require non-negative `min_percent_change` for gappers

Addresses the review comments from PR #130.

## Validation
- `prek run -a`
- `uv run pytest -v -s --cov=src tests`