### PR TITLE
fix(price-history): surface history fetch failures

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,5 +2,6 @@
 
 - `ticker.options` and `ticker.option_chain()` can raise timeout, connection-related errors, or `YFRateLimitError`; in the options tools these must remain `NETWORK_ERROR` and must not be downgraded to `NO_DATA` or generic `API_ERROR`.
 - If a retryable error bucket includes `YFRateLimitError`, the user-facing message must not tell users to check their internet connection; use temporary-network wording or an explicit rate-limit/backoff message instead.
+- Symptom: rate-limit text classifiers can misclassify tickers whose symbol contains rate-limit words. Cause: `str(yfinance_exception)` includes the ticker symbol. Fix: classify using yfinance `debug_info`/`rationale` fields instead of the full exception string when possible.
 
 ## TASTE

--- a/docs/plans/archived/2026-07-07_price-history-raise-errors-plan.md
+++ b/docs/plans/archived/2026-07-07_price-history-raise-errors-plan.md
@@ -1,0 +1,61 @@
+# Price History `raise_errors=True` Plan
+
+## Goal
+
+Make `get_price_history` distinguish "fetch failed" from "genuinely no data": pass `raise_errors=True` to `ticker.history()` so Yahoo-side failures raise exceptions instead of being swallowed into an empty DataFrame and misreported as `NO_DATA`. Add price-history-specific classification so rate limiting and retryable transport failures return `NETWORK_ERROR`, Yahoo upstream/status/auth/blocking failures do not become `NO_DATA`, and invalid symbols/no-price/no-data requests remain `NO_DATA`. Success criteria: rate-limit failures return `NETWORK_ERROR`, invalid symbols or no-data queries return `NO_DATA`, non-no-data Yahoo history failures return `API_ERROR`/`NETWORK_ERROR` as appropriate, and all tests pass.
+
+## Context
+
+- `src/yfmcp/server.py:860-868`: `ticker.history()` currently does not pass `raise_errors`; yfinance defaults to `raise_errors=False`, which swallows all fetch errors and returns an empty DataFrame, falling into the `df.empty` branch at `server.py:889` and misreporting `NO_DATA` (reproduced on 2026-07-07, see issue #134).
+- 2026-07-07 reproduction record: using `CURL_CA_BUNDLE=/dev/null` to simulate the issue #134 reporter's broken-SSL environment, `ticker.history(period="1d", interval="1m")` silently returns an empty df (the log only prints the misleading "possibly delisted; no price data found" with no mention of SSL), while `yf.Search("AAPL")` directly raises `curl_cffi`'s `SSLError` (curl error 77) — exactly matching the two symptoms in the issue (history misreporting NO_DATA, search reporting an SSL error). With `raise_errors=True`, `history()` raises the same `SSLError` in that environment.
+- The inheritance chain of `curl_cffi.requests.exceptions.SSLError` includes `OSError` (SSLError → ConnectionError → RequestException → CurlError → OSError), so it will be caught by `_RETRYABLE_YFINANCE_EXCEPTIONS` (which includes `OSError`) → reported as `NETWORK_ERROR` with the real exception message attached — exactly the behavior we want.
+- **Note**: yfinance 1.5.1 has deprecated the `raise_errors` parameter of `history()` (calls emit a `DeprecationWarning` recommending the global `yf.config.debug.hide_exceptions = False` instead). This plan still uses the per-call `raise_errors=True`, because the global `hide_exceptions = False` would change the error behavior of every yfinance call in the process (search, lookup, base quote, market, etc.), violating the Non-Goals below; see Risks for the deprecation risk.
+- Existing error handling: `_RETRYABLE_YFINANCE_EXCEPTIONS` (`server.py:32`, includes `YFRateLimitError`) → `NETWORK_ERROR`; any other `Exception` → `API_ERROR`.
+- Relevant exceptions in yfinance 1.5.1 under `raise_errors=True` (all inherit from `YFException`):
+  - `YFRateLimitError` — rate limiting; already in the retryable list.
+  - `YFPricesMissingError` — broad history failure wrapper for both genuine no-price/no-data cases and Yahoo chart upstream failures (`debug_info` can include `Yahoo status_code = ...` or `Yahoo error = ...`), so it must be classified by `debug_info`/message rather than blindly mapped to `NO_DATA`.
+  - `YFTzMissingError` — missing ticker timezone; semantically still `NO_DATA` for this tool.
+  - `YFInvalidPeriodError` — invalid period; a user-input problem, semantically also a fit for the `NO_DATA` guidance message.
+
+## Non-Goals
+
+- Do not change error handling of other tools (`get_ticker_info`, `get_financials`, etc.).
+- Do not add a retry mechanism; only do error classification.
+
+## Plan
+
+- [x] In `get_price_history` in `src/yfmcp/server.py`, add `raise_errors=True` to `ticker.history(...)`; verify: `grep -n "raise_errors=True" src/yfmcp/server.py` has a hit.
+- [x] Add imports for `YFPricesMissingError`, `YFTzMissingError`, and `YFInvalidPeriodError` from `yfinance.exceptions`; do not catch broad `YFTickerMissingError`, because `YFPricesMissingError` can represent both no-data and upstream Yahoo chart failures; verify: `uv run ruff check src/yfmcp/server.py` passes.
+- [x] Add a small price-history error helper/classifier in `src/yfmcp/server.py` so `NO_DATA` details consistently include `symbol`, `period`, `interval`, `prepost`, and optional `exception`; classify `YFPricesMissingError` conservatively: known no-data/delisted messages or missing chart data → `NO_DATA`, rate-limit-like messages (`Too Many Requests`, `rate limit`) → `NETWORK_ERROR`, and non-no-data Yahoo `status_code`/`chart.error` messages such as auth/crumb/blocking failures → `API_ERROR`; verify: targeted unit tests below pass.
+- [x] In the `get_price_history` except chain, keep `_RETRYABLE_YFINANCE_EXCEPTIONS` first, then handle `(YFTzMissingError, YFInvalidPeriodError)` as `NO_DATA`, then handle `YFPricesMissingError` via the classifier, and keep the generic `Exception` branch as `API_ERROR`; verify: `uv run pytest tests/test_server_unit.py -k price_history -q` passes.
+- [x] Keep the `df.empty` → `NO_DATA` branch as a safety net (edge cases may still return an empty df under `raise_errors=True`); update it only to reuse the shared no-data helper if one was added; verify: `test_get_price_history_no_data_includes_prepost_detail` still passes.
+- [x] Update/add tests in `tests/test_server_unit.py`:
+  - Add `raise_errors=True` to the existing `history.assert_called_once_with(...)` assertions (around lines 300 and 326).
+  - New: `history` side_effect of `YFRateLimitError` → returns `error_code == "NETWORK_ERROR"` with rate-limit wording.
+  - New: `history` side_effect of `YFTzMissingError("AAPL")` → returns `error_code == "NO_DATA"`.
+  - New: `history` side_effect of `YFInvalidPeriodError("AAPL", "bad", "1d, 5d")` → returns `error_code == "NO_DATA"`.
+  - New: `history` side_effect of `YFPricesMissingError("AAPL", "(period=1d)")` or a delisted/no-data debug string → returns `error_code == "NO_DATA"`.
+  - New: `history` side_effect of `YFPricesMissingError("AAPL", "(period=1d) (Yahoo status_code = 401)")` or `Yahoo error = "Invalid Crumb"` → returns `error_code == "API_ERROR"` (not `NO_DATA`).
+  - New: `history` side_effect of `YFPricesMissingError("AAPL", "(period=1d) (Yahoo error = \"Too Many Requests\")")` → returns `error_code == "NETWORK_ERROR"`.
+  - In at least one new `NO_DATA` exception test, assert `details` contains `symbol`, `period`, `interval`, `prepost`, and `exception`; avoid asserting exact yfinance exception message text elsewhere.
+  - Verify: `uv run pytest tests/ -x -q` all pass.
+- [x] Manual end-to-end verification: call `get_price_history("AAPL", "5d", "1d")` over the real network and get a markdown table (not an error); call with an invalid symbol (e.g. `"NOTAREALTICKER123"`) and get `NO_DATA` rather than `API_ERROR`; verify: record the actual output of both calls.
+- [x] Manually simulate the issue #134 SSL failure: run `get_price_history("AAPL", "1d", "1m")` with `CURL_CA_BUNDLE=/dev/null` and confirm it returns `NETWORK_ERROR` (details containing the SSLError message) rather than the misleading `NO_DATA`; verify: record the actual output.
+- [x] Run repo validation commands: `uv run ruff check .`, `uv run ty check src tests`, and because `.pre-commit-config.yaml` exists, `prek run -a` (fallback: `pre-commit run -a`); verify: command output shows no errors.
+
+## Risks
+
+- `YFPricesMissingError` classification is coupled to yfinance's current `debug_info`/message strings. Keep the classifier conservative: if a `YFPricesMissingError` is not clearly no-data/delisted or rate-limit-like, return `API_ERROR` rather than `NO_DATA`. Tests should assert `error_code` and structured details, not exact yfinance wording except for synthetic classifier fixtures.
+- `YFPricesMissingError` exception text (for example, "possibly delisted") will go into `details.exception`; it is useful signal for LLM users and needs no filtering, but tests should avoid brittle assertions on exact real yfinance messages.
+- `raise_errors=True` behaves differently for multi-symbol requests in yfinance, but this tool only queries a single symbol at a time, so it is unaffected.
+- **`raise_errors` is deprecated (yfinance 1.5.1)**: future versions may remove it; at that point switch to setting `yf.config.debug.hide_exceptions = False` at server startup and re-evaluate the impact on other tools (all tools' except chains already have a generic `Exception` → `API_ERROR` fallback, so nothing will crash, but error response contents will change). Watch the changelog when upgrading yfinance.
+- Each `history(raise_errors=True)` call emits a `DeprecationWarning` to stderr; for an MCP stdio server, stderr is log-only and does not affect the protocol, and Python's default warning filter shows it only once per location — acceptable, no extra filtering needed.
+
+## Completion Checklist
+
+- [x] `ticker.history()` carries `raise_errors=True`, confirmed by `grep -n "raise_errors=True" src/yfmcp/server.py` and the updated call in `src/yfmcp/server.py`.
+- [x] `YFRateLimitError` → `NETWORK_ERROR`, retryable transport errors → `NETWORK_ERROR`, `YFTzMissingError`/`YFInvalidPeriodError` → `NO_DATA`, no-data/delisted `YFPricesMissingError` → `NO_DATA`, rate-limit-like `YFPricesMissingError` → `NETWORK_ERROR`, non-no-data Yahoo status/chart `YFPricesMissingError` → `API_ERROR`, and empty df → `NO_DATA`, confirmed by `uv run pytest tests/ -x -q` (`110 passed`).
+- [x] New exception-path responses preserve structured details (`symbol`, `period`, `interval`, `prepost`, and `exception` where applicable), confirmed by assertions in `tests/test_server_unit.py` and `uv run pytest tests/ -x -q` (`110 passed`).
+- [x] Real call for AAPL 5d/1d successfully returns a table and an invalid symbol returns `NO_DATA`, confirmed by manual run output: AAPL returned a Markdown table beginning with a `Date` header (`lines=7`), and `NOTAREALTICKER123` returned `error_code: NO_DATA`.
+- [x] Simulated SSL failure with `CURL_CA_BUNDLE=/dev/null` returns `NETWORK_ERROR` (not `NO_DATA`), confirmed by manual run output containing curl error 77 in `details.exception`.
+- [x] Validation commands `uv run ruff check .`, `uv run ty check src tests`, and `prek run -a` pass, confirmed by command output (`All checks passed!` / hooks `Passed`).

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -10,7 +10,10 @@ from mcp.types import ImageContent
 from mcp.types import ToolAnnotations
 from pydantic import Field
 from yfinance.const import SECTOR_INDUSTY_MAPPING
+from yfinance.exceptions import YFInvalidPeriodError
+from yfinance.exceptions import YFPricesMissingError
 from yfinance.exceptions import YFRateLimitError
+from yfinance.exceptions import YFTzMissingError
 
 from yfmcp.chart import generate_chart
 from yfmcp.screener import build_screener_query
@@ -52,6 +55,106 @@ def _create_retryable_error_response(action: str, exc: BaseException, details: d
         message = f"Temporary network issue while {action}. Try again later."
 
     return create_error_response(message, error_code="NETWORK_ERROR", details={**details, "exception": str(exc)})
+
+
+def _price_history_details(
+    symbol: str,
+    period: Period,
+    interval: Interval,
+    prepost: bool,
+    exc: BaseException | None = None,
+) -> dict[str, Any]:
+    details: dict[str, Any] = {"symbol": symbol, "period": period, "interval": interval, "prepost": prepost}
+    if exc is not None:
+        details["exception"] = str(exc)
+    return details
+
+
+def _create_price_history_no_data_response(
+    symbol: str,
+    period: Period,
+    interval: Interval,
+    prepost: bool,
+    exc: BaseException | None = None,
+) -> str:
+    return create_error_response(
+        f"No price data available for '{symbol}' with period='{period}' and interval='{interval}'. "
+        "Common issues: (1) Invalid symbol, (2) Incompatible period/interval combination "
+        "(e.g., '1m' interval requires '1d' or '5d' period), (3) Market holidays or insufficient history. "
+        "Try a longer period or daily interval.",
+        error_code="NO_DATA",
+        details=_price_history_details(symbol, period, interval, prepost, exc),
+    )
+
+
+def _create_price_history_api_error_response(
+    symbol: str,
+    period: Period,
+    interval: Interval,
+    prepost: bool,
+    exc: BaseException,
+) -> str:
+    return create_error_response(
+        f"Failed to fetch price history for '{symbol}'. "
+        "Verify the symbol is correct and the period/interval combination is valid.",
+        error_code="API_ERROR",
+        details=_price_history_details(symbol, period, interval, prepost, exc),
+    )
+
+
+def _is_price_history_rate_limit_message(message: str) -> bool:
+    normalized = message.lower()
+    return any(
+        indicator in normalized
+        for indicator in (
+            "too many requests",
+            "rate limit",
+            "rate-limit",
+            "ratelimit",
+            "status_code = 429",
+            "status_code=429",
+        )
+    )
+
+
+def _is_price_history_no_data_prices_missing_error(exc: YFPricesMissingError) -> bool:
+    debug_info = str(getattr(exc, "debug_info", "") or "").lower()
+
+    if "yahoo status_code" in debug_info:
+        return False
+
+    if "yahoo error" in debug_info:
+        return any(
+            indicator in debug_info
+            for indicator in (
+                "no data found",
+                "symbol may be delisted",
+                "possibly delisted",
+            )
+        )
+
+    return True
+
+
+def _create_price_history_prices_missing_error_response(
+    symbol: str,
+    period: Period,
+    interval: Interval,
+    prepost: bool,
+    exc: YFPricesMissingError,
+) -> str:
+    rate_limit_context = f"{getattr(exc, 'debug_info', '')} {getattr(exc, 'rationale', '')}"
+    if _is_price_history_rate_limit_message(rate_limit_context):
+        return create_error_response(
+            f"Rate limit reached while fetching price history for '{symbol}'. Try again later.",
+            error_code="NETWORK_ERROR",
+            details=_price_history_details(symbol, period, interval, prepost, exc),
+        )
+
+    if _is_price_history_no_data_prices_missing_error(exc):
+        return _create_price_history_no_data_response(symbol, period, interval, prepost, exc)
+
+    return _create_price_history_api_error_response(symbol, period, interval, prepost, exc)
 
 
 def _select_retryable_exception(exceptions: list[Exception]) -> BaseException:
@@ -865,36 +968,23 @@ async def get_price_history(
             interval=interval,
             prepost=prepost,
             rounding=True,
+            raise_errors=True,
         )
     except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
         return _create_retryable_error_response(
             f"fetching price history for '{symbol}'",
             exc,
-            {"symbol": symbol, "period": period, "interval": interval, "prepost": prepost},
+            _price_history_details(symbol, period, interval, prepost),
         )
+    except (YFTzMissingError, YFInvalidPeriodError) as exc:
+        return _create_price_history_no_data_response(symbol, period, interval, prepost, exc)
+    except YFPricesMissingError as exc:
+        return _create_price_history_prices_missing_error_response(symbol, period, interval, prepost, exc)
     except Exception as exc:
-        return create_error_response(
-            f"Failed to fetch price history for '{symbol}'. "
-            "Verify the symbol is correct and the period/interval combination is valid.",
-            error_code="API_ERROR",
-            details={
-                "symbol": symbol,
-                "period": period,
-                "interval": interval,
-                "prepost": prepost,
-                "exception": str(exc),
-            },
-        )
+        return _create_price_history_api_error_response(symbol, period, interval, prepost, exc)
 
     if df.empty:
-        return create_error_response(
-            f"No price data available for '{symbol}' with period='{period}' and interval='{interval}'. "
-            "Common issues: (1) Invalid symbol, (2) Incompatible period/interval combination "
-            "(e.g., '1m' interval requires '1d' or '5d' period), (3) Market holidays or insufficient history. "
-            "Try a longer period or daily interval.",
-            error_code="NO_DATA",
-            details={"symbol": symbol, "period": period, "interval": interval, "prepost": prepost},
-        )
+        return _create_price_history_no_data_response(symbol, period, interval, prepost)
 
     if chart_type is None:
         return df.to_markdown()

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -9,7 +9,10 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from yfinance.exceptions import YFInvalidPeriodError
+from yfinance.exceptions import YFPricesMissingError
 from yfinance.exceptions import YFRateLimitError
+from yfinance.exceptions import YFTzMissingError
 
 from yfmcp.server import _build_financials_response
 from yfmcp.server import _industry_key
@@ -297,7 +300,9 @@ async def test_get_price_history_returns_markdown_table_when_chart_type_is_none(
     assert "Open" in result
     assert "Close" in result
     assert "|" in result
-    mock_ticker_obj.history.assert_called_once_with(period="1mo", interval="1d", prepost=False, rounding=True)
+    mock_ticker_obj.history.assert_called_once_with(
+        period="1mo", interval="1d", prepost=False, rounding=True, raise_errors=True
+    )
 
 
 @pytest.mark.asyncio
@@ -323,7 +328,9 @@ async def test_get_price_history_passes_prepost_to_yfinance(mock_to_thread: Asyn
     result = await get_price_history("AAPL", "1d", "1m", None, True)
 
     assert isinstance(result, str)
-    mock_ticker_obj.history.assert_called_once_with(period="1d", interval="1m", prepost=True, rounding=True)
+    mock_ticker_obj.history.assert_called_once_with(
+        period="1d", interval="1m", prepost=True, rounding=True, raise_errors=True
+    )
 
 
 @pytest.mark.asyncio
@@ -363,6 +370,160 @@ async def test_get_price_history_api_error_includes_prepost_detail(
     assert data["error_code"] == "API_ERROR"
     assert data["details"]["prepost"] is True
     assert data["details"]["exception"] == "history failed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), OSError("network unreachable")])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_price_history_retryable_transport_error_returns_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test transport errors while fetching price history return network errors."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.history.side_effect = exception
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_price_history("AAPL", "1d", "1m", None, True)
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["error"] == _expected_retryable_error("fetching price history for 'AAPL'", exception)
+    assert data["details"] == {
+        "symbol": "AAPL",
+        "period": "1d",
+        "interval": "1m",
+        "prepost": True,
+        "exception": str(exception),
+    }
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_price_history_rate_limit_returns_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock
+) -> None:
+    """Test rate limits while fetching price history return network errors."""
+    exception = YFRateLimitError()
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.history.side_effect = exception
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_price_history("AAPL", "1d", "1m", None, True)
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["error"] == "Rate limit reached while fetching price history for 'AAPL'. Try again later."
+    assert data["details"] == {
+        "symbol": "AAPL",
+        "period": "1d",
+        "interval": "1m",
+        "prepost": True,
+        "exception": str(exception),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exception",
+    [
+        YFTzMissingError("AAPL"),
+        YFInvalidPeriodError("AAPL", "bad", "1d, 5d"),
+        YFPricesMissingError("AAPL", " (period=1d)"),
+        YFPricesMissingError("AAPL", ' (period=1d) (Yahoo error = "No data found, symbol may be delisted")'),
+    ],
+)
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_price_history_yfinance_no_data_exceptions_include_details(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test no-data yfinance exceptions include request details and the exception."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.history.side_effect = exception
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_price_history("AAPL", "1d", "1m", None, True)
+    data = json.loads(result)
+
+    assert data["error_code"] == "NO_DATA"
+    assert data["details"] == {
+        "symbol": "AAPL",
+        "period": "1d",
+        "interval": "1m",
+        "prepost": True,
+        "exception": str(exception),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exception",
+    [
+        YFPricesMissingError("AAPL", " (period=1d) (Yahoo status_code = 401)"),
+        YFPricesMissingError("AAPL", ' (period=1d) (Yahoo error = "Invalid Crumb")'),
+    ],
+)
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_price_history_yfinance_prices_missing_upstream_error_returns_api_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock, exception: Exception
+) -> None:
+    """Test upstream Yahoo status/chart errors are not misclassified as no data."""
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.history.side_effect = exception
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_price_history("AAPL", "1d", "1m", None, True)
+    data = json.loads(result)
+
+    assert data["error_code"] == "API_ERROR"
+    assert data["details"]["exception"] == str(exception)
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_price_history_yfinance_prices_missing_rate_limit_returns_network_error(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock
+) -> None:
+    """Test rate-limit-like price-missing errors return network errors."""
+    exception = YFPricesMissingError("AAPL", ' (period=1d) (Yahoo error = "Too Many Requests")')
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.history.side_effect = exception
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_price_history("AAPL", "1d", "1m", None, True)
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["error"] == "Rate limit reached while fetching price history for 'AAPL'. Try again later."
+    assert data["details"]["exception"] == str(exception)
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_price_history_yfinance_prices_missing_symbol_name_does_not_trigger_rate_limit(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock
+) -> None:
+    """Test ticker text alone does not trigger rate-limit classification."""
+    exception = YFPricesMissingError("RATELIMIT", " (period=1d)")
+    mock_ticker_obj = MagicMock()
+    mock_ticker_obj.history.side_effect = exception
+    mock_ticker.return_value = mock_ticker_obj
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_price_history("RATELIMIT", "1d", "1m", None, True)
+    data = json.loads(result)
+
+    assert data["error_code"] == "NO_DATA"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- pass `raise_errors=True` to yfinance history calls so fetch failures surface instead of becoming empty dataframes
- classify price-history yfinance exceptions into `NETWORK_ERROR`, `NO_DATA`, or `API_ERROR` with structured details
- add regression tests for transport errors, rate limits, no-data yfinance exceptions, Yahoo upstream errors, and classifier edge cases

## Verification
- `uv run pytest tests/test_server_unit.py -k price_history -q`
- `uv run pytest tests/ -x -q`
- `uv run ruff check .`
- `uv run ty check src tests`
- `prek run -a`
- manual AAPL 5d/1d history returns a Markdown table
- manual invalid ticker returns `NO_DATA`
- manual `CURL_CA_BUNDLE=/dev/null` SSL simulation returns `NETWORK_ERROR`
