### PR TITLE
Fix MCP Registry publishing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Yahoo Finance MCP Server
 
+<!-- mcp-name: io.github.narumiruna/yfinance-mcp -->
+
 [![PyPI version](https://img.shields.io/pypi/v/yfmcp)](https://pypi.org/project/yfmcp/)
 [![Python](https://img.shields.io/pypi/pyversions/yfmcp.svg)](https://pypi.org/project/yfmcp/)
 [![CI](https://github.com/narumiruna/yfinance-mcp/actions/workflows/python.yml/badge.svg)](https://github.com/narumiruna/yfinance-mcp/actions/workflows/python.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ tag              = true
 commit           = true
 pre_commit_hooks = ["uv lock", "git add uv.lock"]
 
+[[tool.bumpversion.files]]
+filename = "server.json"
+search   = '"version": "{current_version}"'
+replace  = '"version": "{new_version}"'
+
 [tool.pytest]
 filterwarnings = ["ignore::DeprecationWarning"]
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.narumiruna/yfinance-mcp",
+  "title": "Yahoo Finance",
+  "description": "Access Yahoo Finance stock data, news, screeners, options, financials, and charts through MCP.",
+  "websiteUrl": "https://github.com/narumiruna/yfinance-mcp",
+  "repository": {
+    "url": "https://github.com/narumiruna/yfinance-mcp",
+    "source": "github",
+    "id": "957440248"
+  },
+  "version": "0.12.2",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "yfmcp",
+      "version": "0.12.2",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add the MCP Registry ownership marker to the PyPI README metadata
- add and validate `server.json` for the `yfmcp` package
- keep both `server.json` versions synchronized through the bump-version workflow

## Validation

- `prek run -a`
- `mcp-publisher validate`
- `uvx --from 'bump-my-version==1.5.0' bump-my-version bump --dry-run --allow-dirty --no-commit --no-tag -v patch`
- `uv build --no-sources` and verify the ownership marker is present in wheel metadata
