### PR TITLE
Fix uvx startup with MCP SDK v2 available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers     = [
 dependencies    = [
   "loguru>=0.7.3",
   "matplotlib>=3.11.1",
-  "mcp>=1.28.1",
+  "mcp>=1.28.1,<2",
   # Required by pandas.DataFrame.to_markdown() for price history table output.
   "tabulate>=0.10.0",
   "yfinance>=1.5.2",
@@ -25,7 +25,7 @@ yfmcp = "yfmcp.server:main"
 
 [dependency-groups]
 dev = [
-  "mcp[cli]>=1.28.1",
+  "mcp[cli]>=1.28.1,<2",
   "pytest>=9.1.1",
   "pytest-asyncio>=1.4.0",
   "pytest-cov>=7.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1694,14 +1694,14 @@ dev = [
 requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "matplotlib", specifier = ">=3.11.1" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "tabulate", specifier = ">=0.10.0" },
     { name = "yfinance", specifier = ">=1.5.2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },


### PR DESCRIPTION
## Summary

- constrain the runtime MCP SDK dependency to v1
- apply the same constraint to the development dependency
- prevent fresh `uvx yfmcp` environments from resolving MCP SDK v2, which removed `mcp.server.fastmcp`

## Reproduction

The published `yfmcp 0.12.3` resolved `mcp 2.0.0` in a fresh environment and failed during startup with:

```text
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

## Validation

- built the wheel with `uv build --no-sources`
- imported the built wheel in an isolated environment resolving `mcp 1.29.0`
- ran the built wheel's `yfmcp` entry point successfully in an isolated environment
- `uv run pytest -v -s --cov=src tests` (110 passed)
- `prek run -a`
- `uv lock --check`
