### PR TITLE
Add analyst price targets and rating actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## Architecture Overview
 - MCP tools are exposed from `yfmcp.server` with `yfinance_`-prefixed names:
-  `yfinance_get_ticker_info`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`, `yfinance_get_holders`, `yfinance_get_option_chain`, `yfinance_get_option_dates`.
+  `yfinance_get_ticker_info`, `yfinance_get_analyst_price_targets`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`, `yfinance_get_holders`, `yfinance_get_option_chain`, `yfinance_get_option_dates`.
 - All blocking `yfinance` operations MUST be wrapped with `asyncio.to_thread()`.
 - Errors MUST be returned via `create_error_response()` with structured JSON (`error`, `error_code`, optional `details`).
 - Chart responses are returned as base64-encoded WebP `ImageContent`; tabular history uses Markdown tables.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## Architecture Overview
 - MCP tools are exposed from `yfmcp.server` with `yfinance_`-prefixed names:
-  `yfinance_get_ticker_info`, `yfinance_get_analyst_price_targets`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`, `yfinance_get_holders`, `yfinance_get_option_chain`, `yfinance_get_option_dates`.
+  `yfinance_get_ticker_info`, `yfinance_get_analyst_price_targets`, `yfinance_get_upgrades_downgrades`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`, `yfinance_get_holders`, `yfinance_get_option_chain`, `yfinance_get_option_dates`.
 - All blocking `yfinance` operations MUST be wrapped with `asyncio.to_thread()`.
 - Errors MUST be returned via `create_error_response()` with structured JSON (`error`, `error_code`, optional `details`).
 - Chart responses are returned as base64-encoded WebP `ImageContent`; tabular history uses Markdown tables.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that p
 ## Features
 
 - **Stock Data** — Company info, financials, valuation metrics, dividends, and trading data
-- **Analyst Price Targets** — Current price and analyst low, high, mean, and median targets
+- **Analyst Data** — Consensus price targets and firm-level rating and price-target changes
 - **Financial Statements** — Income statement and balance sheet with historical data (EBIT, Invested Capital, etc.)
 - **Financial News** — Recent news articles and press releases for any ticker
 - **Search** — Find stocks, ETFs, and news across Yahoo Finance
@@ -47,6 +47,26 @@ Fetch the current price and analyst consensus price targets for a stock.
 | `symbol` | string | Yes | Stock ticker symbol (e.g. `AAPL`, `GOOGL`, `MSFT`) |
 
 **Returns:** JSON object with `current`, `low`, `high`, `mean`, and `median` price fields. Analyst coverage and available fields vary by symbol.
+
+### `yfinance_get_upgrades_downgrades`
+
+Fetch analyst upgrades, downgrades, initiations, reiterations, and price-target changes, newest first.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | Yes | Stock ticker symbol |
+| `max_rows` | number | No | Maximum actions to return. Default: `25`. Use `0` to return all rows |
+
+**Returns:** JSON object containing `upgrades_downgrades` records and `_metadata` with row counts and truncation status. Records can include:
+
+- `GradeDate`: Date and time of the analyst action
+- `Firm`: Analyst firm name
+- `ToGrade` and `FromGrade`: New and previous ratings
+- `Action`: Rating action
+- `priceTargetAction`: Price-target action such as `Raises`, `Lowers`, or `Maintains`
+- `currentPriceTarget` and `priorPriceTarget`: New and previous price targets
+
+Available fields vary by symbol and analyst action.
 
 ### `yfinance_get_ticker_news`
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that p
 ## Features
 
 - **Stock Data** — Company info, financials, valuation metrics, dividends, and trading data
+- **Analyst Price Targets** — Current price and analyst low, high, mean, and median targets
 - **Financial Statements** — Income statement and balance sheet with historical data (EBIT, Invested Capital, etc.)
 - **Financial News** — Recent news articles and press releases for any ticker
 - **Search** — Find stocks, ETFs, and news across Yahoo Finance
@@ -36,6 +37,16 @@ Retrieve comprehensive stock data including company info, financials, trading me
 | `symbol` | string | Yes | Stock ticker symbol (e.g. `AAPL`, `GOOGL`, `MSFT`) |
 
 **Returns:** JSON object with company details, price data, valuation metrics, trading info, dividends, financials, and performance indicators.
+
+### `yfinance_get_analyst_price_targets`
+
+Fetch the current price and analyst consensus price targets for a stock.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | Yes | Stock ticker symbol (e.g. `AAPL`, `GOOGL`, `MSFT`) |
+
+**Returns:** JSON object with `current`, `low`, `high`, `mean`, and `median` price fields. Analyst coverage and available fields vary by symbol.
 
 ### `yfinance_get_ticker_news`
 

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -285,6 +285,55 @@ async def get_ticker_info(
 
 
 @mcp.tool(
+    name="yfinance_get_analyst_price_targets",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def get_analyst_price_targets(
+    symbol: Annotated[str, Field(description="Stock ticker symbol (e.g., 'AAPL', 'GOOGL', 'MSFT')")],
+) -> str:
+    """Fetch the current price and analyst consensus price targets for a stock.
+
+    Returns a JSON object with the fields supplied by Yahoo Finance:
+    - current: Current market price
+    - low: Lowest analyst price target
+    - high: Highest analyst price target
+    - mean: Mean analyst price target
+    - median: Median analyst price target
+
+    Analyst coverage and available fields vary by symbol.
+    """
+    try:
+        ticker = await asyncio.to_thread(yf.Ticker, symbol)
+        targets = await asyncio.to_thread(lambda: ticker.analyst_price_targets)
+    except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
+        return _create_retryable_error_response(
+            f"fetching analyst price targets for '{symbol}'",
+            exc,
+            {"symbol": symbol},
+        )
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch analyst price targets for '{symbol}'. Verify the symbol is correct.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    if not targets:
+        return create_error_response(
+            f"No analyst price targets available for '{symbol}'.",
+            error_code="NO_DATA",
+            details={"symbol": symbol},
+        )
+
+    return dump_json(targets)
+
+
+@mcp.tool(
     name="yfinance_get_ticker_news",
     annotations=ToolAnnotations(
         readOnlyHint=True,

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -330,7 +330,19 @@ async def get_analyst_price_targets(
             details={"symbol": symbol},
         )
 
-    return dump_json(targets)
+    cleaned_targets: dict[str, Any] = {}
+    for key, value in targets.items():
+        if value is None:
+            cleaned_targets[key] = None
+            continue
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            cleaned_targets[key] = value
+            continue
+        cleaned_targets[key] = None if numeric != numeric else numeric
+
+    return dump_json(cleaned_targets)
 
 
 @mcp.tool(

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -394,6 +394,7 @@ async def get_upgrades_downgrades(
     history = history.sort_index(ascending=False).reset_index()
     total_rows = len(history)
     limited_history = history if max_rows == 0 else history.head(max_rows)
+    limited_history = limited_history.astype(object).where(limited_history.notna(), None)
     records = limited_history.to_dict(orient="records")
 
     return dump_json(

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -334,6 +334,83 @@ async def get_analyst_price_targets(
 
 
 @mcp.tool(
+    name="yfinance_get_upgrades_downgrades",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def get_upgrades_downgrades(
+    symbol: Annotated[str, Field(description="Stock ticker symbol (e.g., 'AAPL', 'GOOGL', 'MSFT')")],
+    max_rows: Annotated[
+        int,
+        Field(description="Maximum analyst actions to return, newest first. Use 0 to return all rows."),
+    ] = 25,
+) -> str:
+    """Fetch analyst upgrades, downgrades, initiations, and price target changes.
+
+    Returns analyst actions newest first. Fields supplied by Yahoo Finance can include:
+    - GradeDate: Date and time of the analyst action
+    - Firm: Analyst firm name
+    - ToGrade and FromGrade: New and previous ratings
+    - Action: Rating action, such as upgrade, downgrade, initiation, or reiteration
+    - priceTargetAction: Price target action, such as Raises, Lowers, or Maintains
+    - currentPriceTarget and priorPriceTarget: New and previous price targets
+
+    Available fields vary by symbol and analyst action.
+    """
+    if max_rows < 0:
+        return create_error_response(
+            "max_rows must be greater than or equal to 0.",
+            error_code="INVALID_PARAMS",
+            details={"max_rows": max_rows},
+        )
+
+    try:
+        ticker = await asyncio.to_thread(yf.Ticker, symbol)
+        history = await asyncio.to_thread(lambda: ticker.upgrades_downgrades)
+    except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
+        return _create_retryable_error_response(
+            f"fetching upgrades and downgrades for '{symbol}'",
+            exc,
+            {"symbol": symbol},
+        )
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch upgrades and downgrades for '{symbol}'. Verify the symbol is correct.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    if history is None or history.empty:
+        return create_error_response(
+            f"No upgrades or downgrades available for '{symbol}'.",
+            error_code="NO_DATA",
+            details={"symbol": symbol},
+        )
+
+    history = history.sort_index(ascending=False).reset_index()
+    total_rows = len(history)
+    limited_history = history if max_rows == 0 else history.head(max_rows)
+    records = limited_history.to_dict(orient="records")
+
+    return dump_json(
+        {
+            "upgrades_downgrades": records,
+            "_metadata": {
+                "symbol": symbol,
+                "max_rows": max_rows,
+                "total_rows": total_rows,
+                "returned_rows": len(records),
+                "truncated": len(records) < total_rows,
+            },
+        }
+    )
+
+
+@mcp.tool(
     name="yfinance_get_ticker_news",
     annotations=ToolAnnotations(
         readOnlyHint=True,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,6 +26,7 @@ async def test_list_tools(server_params: StdioServerParameters) -> None:
         result = await session.list_tools()
         assert len(result.tools) > 0
         assert "yfinance_get_analyst_price_targets" in {tool.name for tool in result.tools}
+        assert "yfinance_get_upgrades_downgrades" in {tool.name for tool in result.tools}
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,6 +25,7 @@ async def test_list_tools(server_params: StdioServerParameters) -> None:
 
         result = await session.list_tools()
         assert len(result.tools) > 0
+        assert "yfinance_get_analyst_price_targets" in {tool.name for tool in result.tools}
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -17,6 +17,7 @@ from yfinance.exceptions import YFTzMissingError
 from yfmcp.server import _build_financials_response
 from yfmcp.server import _industry_key
 from yfmcp.server import _sector_key
+from yfmcp.server import get_analyst_price_targets
 from yfmcp.server import get_financials
 from yfmcp.server import get_holders
 from yfmcp.server import get_option_chain
@@ -50,6 +51,72 @@ def _expected_retryable_error(action: str, exception: Exception) -> str:
     if isinstance(exception, YFRateLimitError):
         return f"Rate limit reached while {action}. Try again later."
     return f"Temporary network issue while {action}. Try again later."
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_analyst_price_targets_success(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test analyst price targets are returned as JSON."""
+    targets = {"current": 225.0, "low": 180.0, "high": 300.0, "mean": 240.0, "median": 235.0}
+    mock_ticker.return_value.analyst_price_targets = targets
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_analyst_price_targets("AAPL")
+
+    assert json.loads(result) == targets
+    mock_ticker.assert_called_once_with("AAPL")
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_analyst_price_targets_no_data(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test missing analyst coverage returns a structured no-data response."""
+    mock_ticker.return_value.analyst_price_targets = {}
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_analyst_price_targets("NOANALYSTS")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NO_DATA"
+    assert data["details"]["symbol"] == "NOANALYSTS"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), OSError("network unreachable"), YFRateLimitError()])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_analyst_price_targets_network_error(
+    mock_to_thread: AsyncMock,
+    mock_ticker: MagicMock,
+    exception: Exception,
+) -> None:
+    """Test retryable analyst target failures return structured network errors."""
+    type(mock_ticker.return_value).analyst_price_targets = PropertyMock(side_effect=exception)
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_analyst_price_targets("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["error"] == _expected_retryable_error("fetching analyst price targets for 'AAPL'", exception)
+    assert data["details"]["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_analyst_price_targets_api_error(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test unexpected analyst target failures return structured API errors."""
+    type(mock_ticker.return_value).analyst_price_targets = PropertyMock(side_effect=RuntimeError("fetch failed"))
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_analyst_price_targets("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "API_ERROR"
+    assert data["details"] == {"symbol": "AAPL", "exception": "fetch failed"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -28,6 +28,7 @@ from yfmcp.server import get_top_etfs
 from yfmcp.server import get_top_growth_companies
 from yfmcp.server import get_top_mutual_funds
 from yfmcp.server import get_top_performing_companies
+from yfmcp.server import get_upgrades_downgrades
 from yfmcp.server import screen
 from yfmcp.server import screen_gappers
 
@@ -113,6 +114,133 @@ async def test_get_analyst_price_targets_api_error(mock_to_thread: AsyncMock, mo
     mock_to_thread.side_effect = _run_to_thread
 
     result = await get_analyst_price_targets("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "API_ERROR"
+    assert data["details"] == {"symbol": "AAPL", "exception": "fetch failed"}
+
+
+def _upgrades_downgrades_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Firm": ["Firm B", "Firm A"],
+            "ToGrade": ["Hold", "Buy"],
+            "FromGrade": ["Buy", "Hold"],
+            "Action": ["down", "up"],
+            "priceTargetAction": ["Lowers", "Raises"],
+            "currentPriceTarget": [200.0, 250.0],
+            "priorPriceTarget": [220.0, 225.0],
+        },
+        index=pd.DatetimeIndex(["2026-07-28 16:00:00", "2026-07-29 18:31:40"], name="GradeDate"),
+    )
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_upgrades_downgrades_success(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test analyst rating history includes firm-level price target changes and metadata."""
+    mock_ticker.return_value.upgrades_downgrades = _upgrades_downgrades_df()
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_upgrades_downgrades("AAPL", max_rows=1)
+    data = json.loads(result)
+
+    assert data["upgrades_downgrades"] == [
+        {
+            "GradeDate": "2026-07-29 18:31:40",
+            "Firm": "Firm A",
+            "ToGrade": "Buy",
+            "FromGrade": "Hold",
+            "Action": "up",
+            "priceTargetAction": "Raises",
+            "currentPriceTarget": 250.0,
+            "priorPriceTarget": 225.0,
+        }
+    ]
+    assert data["_metadata"] == {
+        "symbol": "AAPL",
+        "max_rows": 1,
+        "total_rows": 2,
+        "returned_rows": 1,
+        "truncated": True,
+    }
+    mock_ticker.assert_called_once_with("AAPL")
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_upgrades_downgrades_max_rows_zero_returns_all_rows(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock
+) -> None:
+    """Test max_rows=0 returns the complete analyst action history."""
+    mock_ticker.return_value.upgrades_downgrades = _upgrades_downgrades_df()
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_upgrades_downgrades("AAPL", max_rows=0)
+    data = json.loads(result)
+
+    assert len(data["upgrades_downgrades"]) == 2
+    assert data["_metadata"]["returned_rows"] == 2
+    assert data["_metadata"]["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_upgrades_downgrades_rejects_negative_max_rows() -> None:
+    """Test a negative row limit returns a structured parameter error."""
+    result = await get_upgrades_downgrades("AAPL", max_rows=-1)
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"] == {"max_rows": -1}
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_upgrades_downgrades_no_data(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test missing analyst rating history returns a structured no-data response."""
+    mock_ticker.return_value.upgrades_downgrades = pd.DataFrame()
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_upgrades_downgrades("NOANALYSTS")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NO_DATA"
+    assert data["details"]["symbol"] == "NOANALYSTS"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exception", [TimeoutError("timed out"), OSError("network unreachable"), YFRateLimitError()])
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_upgrades_downgrades_network_error(
+    mock_to_thread: AsyncMock,
+    mock_ticker: MagicMock,
+    exception: Exception,
+) -> None:
+    """Test retryable analyst rating failures return structured network errors."""
+    type(mock_ticker.return_value).upgrades_downgrades = PropertyMock(side_effect=exception)
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_upgrades_downgrades("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["error"] == _expected_retryable_error("fetching upgrades and downgrades for 'AAPL'", exception)
+    assert data["details"]["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_upgrades_downgrades_api_error(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test unexpected analyst rating failures return structured API errors."""
+    type(mock_ticker.return_value).upgrades_downgrades = PropertyMock(side_effect=RuntimeError("fetch failed"))
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_upgrades_downgrades("AAPL")
     data = json.loads(result)
 
     assert data["error_code"] == "API_ERROR"

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -187,6 +187,27 @@ async def test_get_upgrades_downgrades_max_rows_zero_returns_all_rows(
 
 
 @pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_upgrades_downgrades_normalizes_missing_values(
+    mock_to_thread: AsyncMock, mock_ticker: MagicMock
+) -> None:
+    """Test missing analyst fields are encoded as strict JSON null values."""
+    history = _upgrades_downgrades_df()
+    latest_index = history.index.max()
+    history.loc[latest_index, "FromGrade"] = pd.NA
+    history.loc[latest_index, "currentPriceTarget"] = float("nan")
+    mock_ticker.return_value.upgrades_downgrades = history
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_upgrades_downgrades("AAPL")
+    data = json.loads(result, parse_constant=lambda value: pytest.fail(f"Invalid JSON constant: {value}"))
+
+    assert data["upgrades_downgrades"][0]["FromGrade"] is None
+    assert data["upgrades_downgrades"][0]["currentPriceTarget"] is None
+
+
+@pytest.mark.asyncio
 async def test_get_upgrades_downgrades_rejects_negative_max_rows() -> None:
     """Test a negative row limit returns a structured parameter error."""
     result = await get_upgrades_downgrades("AAPL", max_rows=-1)


### PR DESCRIPTION
## Summary

- add `yfinance_get_analyst_price_targets` for current, low, high, mean, and median analyst targets
- add `yfinance_get_upgrades_downgrades` for firm-level rating and price-target actions, newest first
- limit analyst action responses to 25 rows by default, with `max_rows=0` for complete history
- document both MCP tools and their response fields
- cover success, no-data, validation, network, API-error, ordering, and truncation behavior

## Motivation

Expose yfinance's analyst price-target and upgrades/downgrades data through the MCP server. The rating history can include the analyst firm, rating changes, price-target action, and current/prior targets, providing context that the aggregate price-target values alone cannot supply.

## Validation

- `uv run pytest -v -s --cov=src tests` — 124 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check src tests`
- `uv run --with prek prek run -a`
- live MCP calls for UPS and SPCX verified both new tools and firm-level target fields
