### PR TITLE
Add analyst estimates, fund data, and ETF screening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,10 @@
 
 ## Architecture Overview
 - MCP tools are exposed from `yfmcp.server` with `yfinance_`-prefixed names:
-  `yfinance_get_ticker_info`, `yfinance_get_analyst_price_targets`, `yfinance_get_upgrades_downgrades`, `yfinance_get_ticker_news`, `yfinance_search`, `yfinance_get_top`, `yfinance_get_price_history`, `yfinance_get_financials`, `yfinance_get_holders`, `yfinance_get_option_chain`, `yfinance_get_option_dates`.
+  `yfinance_get_ticker_info`, `yfinance_get_analyst_price_targets`, `yfinance_get_analyst_estimates`,
+  `yfinance_get_upgrades_downgrades`, `yfinance_get_fund_data`, `yfinance_get_ticker_news`, `yfinance_search`,
+  `yfinance_get_top`, `yfinance_screen`, `yfinance_get_price_history`, `yfinance_get_financials`,
+  `yfinance_get_holders`, `yfinance_get_option_chain`, `yfinance_get_option_dates`.
 - All blocking `yfinance` operations MUST be wrapped with `asyncio.to_thread()`.
 - Errors MUST be returned via `create_error_response()` with structured JSON (`error`, `error_code`, optional `details`).
 - Chart responses are returned as base64-encoded WebP `ImageContent`; tabular history uses Markdown tables.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that p
 ## Features
 
 - **Stock Data** — Company info, financials, valuation metrics, dividends, and trading data
-- **Analyst Data** — Consensus price targets and firm-level rating and price-target changes
+- **Analyst Data** — Consensus targets, estimate/revision trends, recommendation history, and firm-level actions
 - **Financial Statements** — Income statement and balance sheet with historical data (EBIT, Invested Capital, etc.)
 - **Financial News** — Recent news articles and press releases for any ticker
 - **Search** — Find stocks, ETFs, and news across Yahoo Finance
@@ -25,6 +25,8 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that p
 - **Chart Generation** — Candlestick, VWAP, and volume profile charts returned as WebP images
 - **Options Data** — Option chains with calls, puts, strike prices, IV, and expiration dates
 - **Ownership Data** — Major holders, institutional investors, mutual fund holders, and insider transactions
+- **Fund Look-Through** — ETF and mutual-fund holdings, asset classes, sectors, ratings, and operating details
+- **Screeners** — Predefined, equity, mutual-fund, and ETF query trees
 
 ## Tools
 
@@ -47,6 +49,18 @@ Fetch the current price and analyst consensus price targets for a stock.
 | `symbol` | string | Yes | Stock ticker symbol (e.g. `AAPL`, `GOOGL`, `MSFT`) |
 
 **Returns:** JSON object with `current`, `low`, `high`, `mean`, and `median` price fields. Analyst coverage and available fields vary by symbol.
+
+### `yfinance_get_analyst_estimates`
+
+Fetch analyst consensus estimates, revision momentum, recommendations, growth estimates, and earnings history.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | Yes | Stock ticker symbol |
+| `sections` | array | No | Any of `recommendations`, `earnings_estimate`, `revenue_estimate`, `eps_trend`, `eps_revisions`, `earnings_history`, or `growth_estimates`. Omit for all sections |
+| `max_rows` | number | No | Maximum rows per section. Default: `12`. Use `0` for all rows |
+
+**Returns:** Named arrays for available sections plus `_metadata` containing per-section row counts, truncation status, unavailable sections, and failed sections. A failure in one section does not discard successfully fetched sections.
 
 ### `yfinance_get_upgrades_downgrades`
 
@@ -111,8 +125,8 @@ Run Yahoo Finance screeners using either predefined screener keys or custom quer
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `query` | string/object | Yes | For `query_type="predefined"`: screener key such as `"day_gainers"`. For `query_type="equity"` or `"fund"`: custom query tree with `{operator, operands}` nodes |
-| `query_type` | string | No | `"predefined"` (default), `"equity"`, or `"fund"` |
+| `query` | string/object | Yes | For `query_type="predefined"`: screener key such as `"day_gainers"`. For `query_type="equity"`, `"fund"`, or `"etf"`: custom query tree with `{operator, operands}` nodes |
+| `query_type` | string | No | `"predefined"` (default), `"equity"`, `"fund"`, or `"etf"` |
 | `offset` | number | No | Result offset |
 | `size` | number | No | Rows for custom queries; Yahoo maximum is `250` |
 | `count` | number | No | Rows for predefined queries; Yahoo maximum is `250` |
@@ -140,6 +154,24 @@ Custom equity screener example:
   "sort_field": "percentchange",
   "sort_asc": false,
   "size": 50
+}
+```
+
+Custom ETF screener example:
+
+```json
+{
+  "query_type": "etf",
+  "query": {
+    "operator": "and",
+    "operands": [
+      { "operator": "eq", "operands": ["categoryname", "Large Blend"] },
+      { "operator": "lte", "operands": ["annualreportnetexpenseratio", 0.2] }
+    ]
+  },
+  "sort_field": "fundnetassets",
+  "sort_asc": false,
+  "size": 25
 }
 ```
 
@@ -218,6 +250,18 @@ Fetch major holders, institutional holders, mutual fund holders, and insider dat
 - **`_metadata`** — Row limit metadata with `max_rows` and per-section `total_rows`, `returned_rows`, and `truncated`
 
 Holder sections are limited to 10 rows by default to keep responses concise. Pass `max_rows: 0` when you need the complete holder datasets. Field names for holder-related datasets are provided by `yfinance` and may vary by ticker, data availability, and `yfinance` version.
+
+### `yfinance_get_fund_data`
+
+Fetch ETF or mutual-fund portfolio composition and operating details.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | Yes | ETF or mutual-fund ticker symbol (for example `SPY`, `BND`, or `VFIAX`) |
+| `sections` | array | No | Any of `description`, `fund_overview`, `fund_operations`, `asset_classes`, `top_holdings`, `equity_holdings`, `bond_holdings`, `bond_ratings`, or `sector_weightings`. Omit for all sections |
+| `max_rows` | number | No | Maximum rows per tabular section. Default: `25`. Use `0` for all rows |
+
+**Returns:** Available fund sections plus `_metadata` with row limits, per-section truncation, unavailable sections, and failed sections. The mix of sections depends on the fund; for example, equity funds and bond funds expose different portfolio breakdowns.
 
 ### `yfinance_get_option_dates`
 

--- a/src/yfmcp/screener.py
+++ b/src/yfmcp/screener.py
@@ -4,10 +4,11 @@ from typing import Any
 from typing import cast
 
 from yfinance import EquityQuery
+from yfinance import ETFQuery
 from yfinance import FundQuery
 from yfinance.screener.query import Operator
 
-ScreenerQuery = EquityQuery | FundQuery
+ScreenerQuery = EquityQuery | FundQuery | ETFQuery
 
 LEAF_OPERATORS = {"eq", "is-in", "btwn", "gt", "lt", "gte", "lte"}
 LOGICAL_OPERATORS = {"and", "or"}
@@ -20,8 +21,10 @@ def build_screener_query(query_type: str, query: dict[str, Any]) -> ScreenerQuer
             return _build_equity_node(query)
         case "fund":
             return _build_fund_node(query)
+        case "etf":
+            return _build_etf_node(query)
         case _:
-            raise ValueError("query_type must be 'equity' or 'fund' for custom queries")
+            raise ValueError("query_type must be 'equity', 'fund', or 'etf' for custom queries")
 
 
 def _validate_node_shape(node: dict[str, Any]) -> tuple[Operator, list[Any]]:
@@ -77,4 +80,22 @@ def _build_fund_node(node: dict[str, Any]) -> FundQuery:
         if any(isinstance(operand, dict) for operand in operands):
             raise ValueError(f"Operator '{normalized_operator.upper()}' does not accept nested query objects")
         return FundQuery(normalized_operator, operands)
+    raise ValueError(f"Unsupported operator '{normalized_operator.upper()}'")
+
+
+def _build_etf_node(node: dict[str, Any]) -> ETFQuery:
+    normalized_operator, operands = _validate_node_shape(node)
+
+    if normalized_operator in LOGICAL_OPERATORS:
+        nested_queries: list[ETFQuery] = []
+        for operand in operands:
+            if not isinstance(operand, dict):
+                raise ValueError(f"Operator '{normalized_operator.upper()}' requires nested query objects")
+            nested_queries.append(_build_etf_node(cast(dict[str, Any], operand)))
+        return ETFQuery(normalized_operator, cast(Any, nested_queries))
+
+    if normalized_operator in LEAF_OPERATORS:
+        if any(isinstance(operand, dict) for operand in operands):
+            raise ValueError(f"Operator '{normalized_operator.upper()}' does not accept nested query objects")
+        return ETFQuery(normalized_operator, operands)
     raise ValueError(f"Unsupported operator '{normalized_operator.upper()}'")

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -1,5 +1,7 @@
 import asyncio
+import math
 from datetime import datetime
+from numbers import Real
 from typing import Annotated
 from typing import Any
 
@@ -10,6 +12,7 @@ from mcp.types import ImageContent
 from mcp.types import ToolAnnotations
 from pydantic import Field
 from yfinance.const import SECTOR_INDUSTY_MAPPING
+from yfinance.exceptions import YFDataException
 from yfinance.exceptions import YFInvalidPeriodError
 from yfinance.exceptions import YFPricesMissingError
 from yfinance.exceptions import YFRateLimitError
@@ -38,6 +41,28 @@ _RETRYABLE_YFINANCE_EXCEPTIONS: tuple[type[Exception], ...] = (
     OSError,
     YFRateLimitError,
 )
+
+_ANALYST_ESTIMATE_SECTIONS: dict[str, tuple[str, str | None, bool]] = {
+    "recommendations": ("recommendations", None, False),
+    "earnings_estimate": ("earnings_estimate", "period", False),
+    "revenue_estimate": ("revenue_estimate", "period", False),
+    "eps_trend": ("eps_trend", "period", False),
+    "eps_revisions": ("eps_revisions", "period", False),
+    "earnings_history": ("earnings_history", "date", True),
+    "growth_estimates": ("growth_estimates", "period", False),
+}
+
+_FUND_DATA_SECTIONS = {
+    "description",
+    "fund_overview",
+    "fund_operations",
+    "asset_classes",
+    "top_holdings",
+    "equity_holdings",
+    "bond_holdings",
+    "bond_ratings",
+    "sector_weightings",
+}
 
 
 def _is_retryable_yfinance_error(exc: BaseException) -> bool:
@@ -160,6 +185,140 @@ def _create_price_history_prices_missing_error_response(
 def _select_retryable_exception(exceptions: list[Exception]) -> BaseException:
     rate_limit_exception = next((exc for exc in exceptions if _is_rate_limit_error(exc)), None)
     return rate_limit_exception or exceptions[0]
+
+
+def _normalize_json_value(value: Any) -> Any:
+    """Replace non-finite numeric values recursively so responses remain strict JSON."""
+    if isinstance(value, dict):
+        return {key: _normalize_json_value(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_normalize_json_value(item) for item in value]
+    if isinstance(value, Real) and not math.isfinite(float(value)):
+        return None
+    return value
+
+
+def _dataframe_records(
+    frame: Any,
+    max_rows: int,
+    *,
+    include_index: bool,
+    index_name: str | None = None,
+    sort_descending: bool = False,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    prepared = frame.copy()
+    if sort_descending:
+        prepared = prepared.sort_index(ascending=False)
+    if include_index:
+        if index_name is not None:
+            prepared.index.name = index_name
+        prepared = prepared.reset_index()
+
+    total_rows = len(prepared)
+    limited = prepared if max_rows == 0 else prepared.head(max_rows)
+    limited = limited.astype(object).where(limited.notna(), None)
+    records = _normalize_json_value(limited.to_dict(orient="records"))
+    return records, {
+        "total_rows": total_rows,
+        "returned_rows": len(records),
+        "truncated": len(records) < total_rows,
+    }
+
+
+def _serialize_fund_section(value: Any, max_rows: int) -> tuple[Any, dict[str, Any] | None] | None:
+    if value is None or (hasattr(value, "empty") and value.empty):
+        return None
+    if isinstance(value, dict | list | str) and not value:
+        return None
+    if hasattr(value, "columns") and hasattr(value, "index"):
+        records, metadata = _dataframe_records(value, max_rows, include_index=True)
+        return records, metadata
+    return _normalize_json_value(value), None
+
+
+async def _fetch_fund_sections(
+    funds_data: Any,
+    selected_sections: list[str],
+    max_rows: int,
+) -> tuple[dict[str, Any], dict[str, Any], list[str], list[tuple[str, Exception]]]:
+    response: dict[str, Any] = {}
+    section_metadata: dict[str, Any] = {}
+    unavailable_sections: list[str] = []
+    fetch_errors: list[tuple[str, Exception]] = []
+
+    for section in selected_sections:
+        try:
+            value = await asyncio.to_thread(lambda section=section: getattr(funds_data, section))
+            serialized = _serialize_fund_section(value, max_rows)
+            if serialized is None:
+                unavailable_sections.append(section)
+                continue
+            response[section], metadata = serialized
+            if metadata is not None:
+                section_metadata[section] = metadata
+        except YFDataException:
+            unavailable_sections.append(section)
+        except Exception as exc:
+            fetch_errors.append((section, exc))
+
+    return response, section_metadata, unavailable_sections, fetch_errors
+
+
+def _validate_sections(
+    sections: list[str] | None,
+    valid_sections: set[str],
+    *,
+    max_rows: int,
+) -> tuple[list[str] | None, str | None]:
+    if max_rows < 0:
+        return None, create_error_response(
+            "max_rows must be greater than or equal to 0.",
+            error_code="INVALID_PARAMS",
+            details={"max_rows": max_rows},
+        )
+    if sections is not None and not sections:
+        return None, create_error_response(
+            "sections must include at least one section when provided.",
+            error_code="INVALID_PARAMS",
+            details={"sections": sections, "valid_sections": sorted(valid_sections)},
+        )
+
+    selected = sorted(valid_sections) if sections is None else list(dict.fromkeys(sections))
+    invalid = sorted(set(selected).difference(valid_sections))
+    if invalid:
+        return None, create_error_response(
+            "One or more requested sections are invalid.",
+            error_code="INVALID_PARAMS",
+            details={"invalid_sections": invalid, "valid_sections": sorted(valid_sections)},
+        )
+    return selected, None
+
+
+def _section_fetch_error_response(
+    symbol: str,
+    subject: str,
+    selected_sections: list[str],
+    fetch_errors: list[tuple[str, Exception]],
+) -> str:
+    retryable = [exc for _, exc in fetch_errors if _is_retryable_yfinance_error(exc)]
+    failed_sections = [section for section, _ in fetch_errors]
+    details: dict[str, Any] = {
+        "symbol": symbol,
+        "requested_sections": selected_sections,
+        "failed_sections": failed_sections,
+    }
+    if retryable:
+        return _create_retryable_error_response(
+            f"fetching {subject} for '{symbol}'",
+            _select_retryable_exception(retryable),
+            details,
+        )
+    details["exception"] = str(fetch_errors[0][1])
+    return create_error_response(
+        f"Failed to fetch {subject} for '{symbol}'.",
+        error_code="API_ERROR",
+        details=details,
+    )
 
 
 def _create_option_dates_fetch_error(symbol: str, exc: Exception, api_message: str) -> str:
@@ -343,6 +502,185 @@ async def get_analyst_price_targets(
         cleaned_targets[key] = None if numeric != numeric else numeric
 
     return dump_json(cleaned_targets)
+
+
+@mcp.tool(
+    name="yfinance_get_analyst_estimates",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def get_analyst_estimates(
+    symbol: Annotated[str, Field(description="Stock ticker symbol (e.g., 'AAPL', 'GOOGL', 'MSFT')")],
+    sections: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                "Optional analyst sections: recommendations, earnings_estimate, revenue_estimate, eps_trend, "
+                "eps_revisions, earnings_history, and growth_estimates. Omit to return all sections."
+            )
+        ),
+    ] = None,
+    max_rows: Annotated[
+        int,
+        Field(description="Maximum rows per section. Use 0 to return all rows."),
+    ] = 12,
+) -> str:
+    """Fetch consensus estimates, EPS/revenue trends, revisions, recommendations, and earnings history."""
+    selected_sections, validation_error = _validate_sections(
+        sections,
+        set(_ANALYST_ESTIMATE_SECTIONS),
+        max_rows=max_rows,
+    )
+    if validation_error is not None:
+        return validation_error
+    assert selected_sections is not None
+
+    try:
+        ticker = await asyncio.to_thread(yf.Ticker, symbol)
+    except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
+        return _create_retryable_error_response(
+            f"fetching analyst estimates for '{symbol}'",
+            exc,
+            {"symbol": symbol},
+        )
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch analyst estimates for '{symbol}'.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    response: dict[str, Any] = {}
+    section_metadata: dict[str, Any] = {}
+    unavailable_sections: list[str] = []
+    fetch_errors: list[tuple[str, Exception]] = []
+
+    for section in selected_sections:
+        attribute, index_name, sort_descending = _ANALYST_ESTIMATE_SECTIONS[section]
+        try:
+            frame = await asyncio.to_thread(lambda attribute=attribute: getattr(ticker, attribute))
+            if frame is None or frame.empty:
+                unavailable_sections.append(section)
+                continue
+            records, metadata = _dataframe_records(
+                frame,
+                max_rows,
+                include_index=index_name is not None,
+                index_name=index_name,
+                sort_descending=sort_descending,
+            )
+            response[section] = records
+            section_metadata[section] = metadata
+        except Exception as exc:
+            fetch_errors.append((section, exc))
+
+    if not response:
+        if fetch_errors:
+            return _section_fetch_error_response(
+                symbol,
+                "analyst estimates",
+                selected_sections,
+                fetch_errors,
+            )
+        return create_error_response(
+            f"No analyst estimates available for '{symbol}'.",
+            error_code="NO_DATA",
+            details={"symbol": symbol, "requested_sections": selected_sections},
+        )
+
+    response["_metadata"] = {
+        "symbol": symbol,
+        "max_rows": max_rows,
+        "requested_sections": selected_sections,
+        "sections": section_metadata,
+        "unavailable_sections": unavailable_sections,
+        "failed_sections": [section for section, _ in fetch_errors],
+    }
+    return dump_json(response)
+
+
+@mcp.tool(
+    name="yfinance_get_fund_data",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def get_fund_data(
+    symbol: Annotated[str, Field(description="ETF or mutual fund ticker symbol (e.g., 'SPY', 'BND', 'VFIAX')")],
+    sections: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                "Optional fund sections: description, fund_overview, fund_operations, asset_classes, "
+                "top_holdings, equity_holdings, bond_holdings, bond_ratings, and sector_weightings. "
+                "Omit to return all sections."
+            )
+        ),
+    ] = None,
+    max_rows: Annotated[
+        int,
+        Field(description="Maximum rows per tabular section. Use 0 to return all rows."),
+    ] = 25,
+) -> str:
+    """Fetch ETF or mutual-fund composition, holdings, exposures, ratings, and operating details."""
+    selected_sections, validation_error = _validate_sections(
+        sections,
+        _FUND_DATA_SECTIONS,
+        max_rows=max_rows,
+    )
+    if validation_error is not None:
+        return validation_error
+    assert selected_sections is not None
+
+    try:
+        ticker = await asyncio.to_thread(yf.Ticker, symbol)
+        funds_data = await asyncio.to_thread(lambda: ticker.funds_data)
+    except _RETRYABLE_YFINANCE_EXCEPTIONS as exc:
+        return _create_retryable_error_response(f"fetching fund data for '{symbol}'", exc, {"symbol": symbol})
+    except YFDataException as exc:
+        return create_error_response(
+            f"No fund data available for '{symbol}'.",
+            error_code="NO_DATA",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+    except Exception as exc:
+        return create_error_response(
+            f"Failed to fetch fund data for '{symbol}'. Verify that the symbol is an ETF or mutual fund.",
+            error_code="API_ERROR",
+            details={"symbol": symbol, "exception": str(exc)},
+        )
+
+    response, section_metadata, unavailable_sections, fetch_errors = await _fetch_fund_sections(
+        funds_data,
+        selected_sections,
+        max_rows,
+    )
+
+    if not response:
+        if fetch_errors:
+            return _section_fetch_error_response(symbol, "fund data", selected_sections, fetch_errors)
+        return create_error_response(
+            f"No fund data available for '{symbol}'.",
+            error_code="NO_DATA",
+            details={"symbol": symbol, "requested_sections": selected_sections},
+        )
+
+    response["_metadata"] = {
+        "symbol": symbol,
+        "max_rows": max_rows,
+        "requested_sections": selected_sections,
+        "sections": section_metadata,
+        "unavailable_sections": unavailable_sections,
+        "failed_sections": [section for section, _ in fetch_errors],
+    }
+    return dump_json(response)
 
 
 @mcp.tool(
@@ -558,13 +896,13 @@ async def screen(
         Field(
             description=(
                 "Screener query. For query_type='predefined': string key like 'day_gainers'. "
-                "For query_type='equity' or 'fund': query tree object with {operator, operands} nodes."
+                "For query_type='equity', 'fund', or 'etf': query tree object with {operator, operands} nodes."
             )
         ),
     ],
     query_type: Annotated[
         ScreenerQueryType,
-        Field(description="Query mode: 'predefined', 'equity', or 'fund'."),
+        Field(description="Query mode: 'predefined', 'equity', 'fund', or 'etf'."),
     ] = "predefined",
     offset: Annotated[int | None, Field(description="Result offset.", ge=0)] = None,
     size: Annotated[
@@ -582,7 +920,7 @@ async def screen(
 ) -> str:
     """Run a Yahoo Finance screener query.
 
-    Supports predefined Yahoo screener keys and custom equity or fund query trees.
+    Supports predefined Yahoo screener keys and custom equity, mutual-fund, or ETF query trees.
     """
     try:
         if query_type == "predefined" and size is not None:
@@ -591,9 +929,9 @@ async def screen(
                 error_code="INVALID_PARAMS",
                 details={"query_type": query_type, "invalid_parameter": "size", "expected_parameter": "count"},
             )
-        if query_type in {"equity", "fund"} and count is not None:
+        if query_type in {"equity", "fund", "etf"} and count is not None:
             return create_error_response(
-                "For query_type='equity' or 'fund', use size instead of count.",
+                "For query_type='equity', 'fund', or 'etf', use size instead of count.",
                 error_code="INVALID_PARAMS",
                 details={"query_type": query_type, "invalid_parameter": "count", "expected_parameter": "size"},
             )
@@ -622,7 +960,8 @@ async def screen(
         else:
             if not isinstance(query, dict):
                 return create_error_response(
-                    "For query_type='equity' or 'fund', query must be an object with 'operator' and 'operands'.",
+                    "For query_type='equity', 'fund', or 'etf', query must be an object with "
+                    "'operator' and 'operands'.",
                     error_code="INVALID_PARAMS",
                     details={"query_type": query_type, "expected_query_type": "object"},
                 )

--- a/src/yfmcp/server.py
+++ b/src/yfmcp/server.py
@@ -191,7 +191,7 @@ def _normalize_json_value(value: Any) -> Any:
     """Replace non-finite numeric values recursively so responses remain strict JSON."""
     if isinstance(value, dict):
         return {key: _normalize_json_value(item) for key, item in value.items()}
-    if isinstance(value, list | tuple):
+    if isinstance(value, (list, tuple)):
         return [_normalize_json_value(item) for item in value]
     if isinstance(value, Real) and not math.isfinite(float(value)):
         return None
@@ -228,7 +228,7 @@ def _dataframe_records(
 def _serialize_fund_section(value: Any, max_rows: int) -> tuple[Any, dict[str, Any] | None] | None:
     if value is None or (hasattr(value, "empty") and value.empty):
         return None
-    if isinstance(value, dict | list | str) and not value:
+    if isinstance(value, (dict, list, str)) and not value:
         return None
     if hasattr(value, "columns") and hasattr(value, "index"):
         records, metadata = _dataframe_records(value, max_rows, include_index=True)

--- a/src/yfmcp/types.py
+++ b/src/yfmcp/types.py
@@ -83,6 +83,7 @@ ScreenerQueryType = Literal[
     "predefined",
     "equity",
     "fund",
+    "etf",
 ]
 
 OptionChainType = Literal[

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,5 +1,6 @@
 import pytest
 from yfinance import EquityQuery
+from yfinance import ETFQuery
 from yfinance import FundQuery
 
 from yfmcp.screener import build_screener_query
@@ -38,6 +39,22 @@ def test_build_fund_query_success() -> None:
     assert result.operator == "AND"
 
 
+def test_build_etf_query_success() -> None:
+    """Test JSON-style ETF query trees build yfinance ETFQuery objects."""
+    query = {
+        "operator": "and",
+        "operands": [
+            {"operator": "eq", "operands": ["categoryname", "Large Blend"]},
+            {"operator": "lte", "operands": ["annualreportnetexpenseratio", 0.2]},
+        ],
+    }
+
+    result = build_screener_query("etf", query)
+
+    assert isinstance(result, ETFQuery)
+    assert result.operator == "AND"
+
+
 def test_build_query_invalid_operator() -> None:
     """Test unsupported operators are rejected."""
     query = {"operator": "contains", "operands": ["region", "us"]}
@@ -47,8 +64,8 @@ def test_build_query_invalid_operator() -> None:
 
 
 def test_build_query_invalid_type() -> None:
-    """Test custom query builder only accepts equity and fund query types."""
+    """Test custom query builder only accepts equity, fund, and ETF query types."""
     query = {"operator": "eq", "operands": ["region", "us"]}
 
-    with pytest.raises(ValueError, match="query_type must be 'equity' or 'fund'"):
+    with pytest.raises(ValueError, match="query_type must be 'equity', 'fund', or 'etf'"):
         build_screener_query("predefined", query)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,6 +26,8 @@ async def test_list_tools(server_params: StdioServerParameters) -> None:
         result = await session.list_tools()
         assert len(result.tools) > 0
         assert "yfinance_get_analyst_price_targets" in {tool.name for tool in result.tools}
+        assert "yfinance_get_analyst_estimates" in {tool.name for tool in result.tools}
+        assert "yfinance_get_fund_data" in {tool.name for tool in result.tools}
         assert "yfinance_get_upgrades_downgrades" in {tool.name for tool in result.tools}
 
 

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from yfinance.exceptions import YFDataException
 from yfinance.exceptions import YFInvalidPeriodError
 from yfinance.exceptions import YFPricesMissingError
 from yfinance.exceptions import YFRateLimitError
@@ -17,8 +18,10 @@ from yfinance.exceptions import YFTzMissingError
 from yfmcp.server import _build_financials_response
 from yfmcp.server import _industry_key
 from yfmcp.server import _sector_key
+from yfmcp.server import get_analyst_estimates
 from yfmcp.server import get_analyst_price_targets
 from yfmcp.server import get_financials
+from yfmcp.server import get_fund_data
 from yfmcp.server import get_holders
 from yfmcp.server import get_option_chain
 from yfmcp.server import get_option_dates
@@ -118,6 +121,217 @@ async def test_get_analyst_price_targets_api_error(mock_to_thread: AsyncMock, mo
 
     assert data["error_code"] == "API_ERROR"
     assert data["details"] == {"symbol": "AAPL", "exception": "fetch failed"}
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_analyst_estimates_success(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test selected analyst estimate sections return records and per-section metadata."""
+    ticker = mock_ticker.return_value
+    ticker.recommendations = pd.DataFrame(
+        {
+            "period": ["0m", "-1m"],
+            "strongBuy": [12, 10],
+            "buy": [20, 19],
+            "hold": [8, 9],
+            "sell": [1, 1],
+            "strongSell": [0, 0],
+        }
+    )
+    ticker.eps_revisions = pd.DataFrame(
+        {
+            "upLast7days": [2.0, float("nan")],
+            "upLast30days": [4, 3],
+            "downLast30days": [1, 2],
+            "downLast7Days": [0, 1],
+        },
+        index=["0q", "+1q"],
+    )
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_analyst_estimates("AAPL", sections=["eps_revisions", "recommendations"], max_rows=1)
+    data = json.loads(result, parse_constant=lambda value: pytest.fail(f"Invalid JSON constant: {value}"))
+
+    assert data["eps_revisions"] == [
+        {"period": "0q", "upLast7days": 2.0, "upLast30days": 4, "downLast30days": 1, "downLast7Days": 0}
+    ]
+    assert data["recommendations"][0]["period"] == "0m"
+    assert data["_metadata"]["sections"]["eps_revisions"] == {
+        "total_rows": 2,
+        "returned_rows": 1,
+        "truncated": True,
+    }
+    assert data["_metadata"]["failed_sections"] == []
+    assert data["_metadata"]["unavailable_sections"] == []
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_analyst_estimates_partial_failure(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test one failing section does not discard other analyst data."""
+
+    class PartialAnalystTicker:
+        recommendations = pd.DataFrame({"period": ["0m"], "buy": [20]})
+
+        @property
+        def eps_trend(self):
+            raise RuntimeError("trend unavailable")
+
+    mock_ticker.return_value = PartialAnalystTicker()
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_analyst_estimates("AAPL", sections=["recommendations", "eps_trend"])
+    data = json.loads(result)
+
+    assert data["recommendations"] == [{"period": "0m", "buy": 20}]
+    assert data["_metadata"]["failed_sections"] == ["eps_trend"]
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_analyst_estimates_no_data(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test an empty requested analyst section returns a structured no-data response."""
+    mock_ticker.return_value.recommendations = pd.DataFrame()
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_analyst_estimates("NOANALYSTS", sections=["recommendations"])
+    data = json.loads(result)
+
+    assert data["error_code"] == "NO_DATA"
+    assert data["details"] == {"symbol": "NOANALYSTS", "requested_sections": ["recommendations"]}
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_analyst_estimates_network_error(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test a retryable section failure returns a structured network error when no data succeeds."""
+    type(mock_ticker.return_value).eps_trend = PropertyMock(side_effect=TimeoutError("timed out"))
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_analyst_estimates("AAPL", sections=["eps_trend"])
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["details"]["failed_sections"] == ["eps_trend"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sections", "max_rows", "detail_key"),
+    [([], 12, "sections"), (["not_a_section"], 12, "invalid_sections"), (None, -1, "max_rows")],
+)
+async def test_get_analyst_estimates_rejects_invalid_parameters(
+    sections: list[str] | None,
+    max_rows: int,
+    detail_key: str,
+) -> None:
+    """Test analyst section selection and row limits are validated before fetching."""
+    result = await get_analyst_estimates("AAPL", sections=sections, max_rows=max_rows)
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert detail_key in data["details"]
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_fund_data_success(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test fund exposures and limited holdings are returned with strict JSON values."""
+    funds_data = MagicMock()
+    funds_data.asset_classes = {"stockPosition": 0.995, "otherPosition": float("nan")}
+    funds_data.top_holdings = pd.DataFrame(
+        {"Name": ["Apple Inc.", "Microsoft Corp."], "Holding Percent": [0.07, 0.06]},
+        index=pd.Index(["AAPL", "MSFT"], name="Symbol"),
+    )
+    mock_ticker.return_value.funds_data = funds_data
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_fund_data("SPY", sections=["asset_classes", "top_holdings"], max_rows=1)
+    data = json.loads(result, parse_constant=lambda value: pytest.fail(f"Invalid JSON constant: {value}"))
+
+    assert data["asset_classes"] == {"stockPosition": 0.995, "otherPosition": None}
+    assert data["top_holdings"] == [{"Symbol": "AAPL", "Name": "Apple Inc.", "Holding Percent": 0.07}]
+    assert data["_metadata"]["sections"]["top_holdings"] == {
+        "total_rows": 2,
+        "returned_rows": 1,
+        "truncated": True,
+    }
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_fund_data_partial_failure(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test one failing fund section does not discard other fund data."""
+
+    class PartialFundsData:
+        asset_classes = {"stockPosition": 1.0}
+
+        @property
+        def top_holdings(self):
+            raise RuntimeError("holdings unavailable")
+
+    mock_ticker.return_value.funds_data = PartialFundsData()
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_fund_data("SPY", sections=["asset_classes", "top_holdings"])
+    data = json.loads(result)
+
+    assert data["asset_classes"] == {"stockPosition": 1.0}
+    assert data["_metadata"]["failed_sections"] == ["top_holdings"]
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_fund_data_network_error(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test retryable fund-data failures return structured network errors."""
+    mock_ticker.side_effect = TimeoutError("timed out")
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_fund_data("SPY")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NETWORK_ERROR"
+    assert data["details"]["symbol"] == "SPY"
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.yf.Ticker")
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_get_fund_data_non_fund_returns_no_data(mock_to_thread: AsyncMock, mock_ticker: MagicMock) -> None:
+    """Test equities without fund data produce a structured no-data response."""
+    type(mock_ticker.return_value).funds_data = PropertyMock(side_effect=YFDataException("No Fund data found"))
+    mock_to_thread.side_effect = _run_to_thread
+
+    result = await get_fund_data("AAPL")
+    data = json.loads(result)
+
+    assert data["error_code"] == "NO_DATA"
+    assert data["details"]["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sections", "max_rows", "detail_key"),
+    [([], 25, "sections"), (["not_a_section"], 25, "invalid_sections"), (None, -1, "max_rows")],
+)
+async def test_get_fund_data_rejects_invalid_parameters(
+    sections: list[str] | None,
+    max_rows: int,
+    detail_key: str,
+) -> None:
+    """Test fund section selection and row limits are validated before fetching."""
+    result = await get_fund_data("SPY", sections=sections, max_rows=max_rows)
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert detail_key in data["details"]
 
 
 def _upgrades_downgrades_df() -> pd.DataFrame:
@@ -1832,11 +2046,49 @@ async def test_screen_custom_equity_success(mock_to_thread: AsyncMock) -> None:
 
 @pytest.mark.asyncio
 @patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_custom_etf_success(mock_to_thread: AsyncMock) -> None:
+    """Test custom ETF screener query execution."""
+    mock_to_thread.return_value = {"quotes": [{"symbol": "VTI"}], "total": 1}
+    query = {
+        "operator": "and",
+        "operands": [
+            {"operator": "eq", "operands": ["categoryname", "Large Blend"]},
+            {"operator": "lte", "operands": ["annualreportnetexpenseratio", 0.2]},
+        ],
+    }
+
+    result = await screen(query, query_type="etf", size=20, sort_field="fundnetassets", sort_asc=False)
+    data = json.loads(result)
+
+    assert data["quotes"] == [{"symbol": "VTI"}]
+    mock_to_thread.assert_called_once()
+    _, kwargs = mock_to_thread.call_args
+    assert kwargs["size"] == 20
+    assert kwargs["count"] is None
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.asyncio.to_thread")
 async def test_screen_custom_rejects_count_parameter(mock_to_thread: AsyncMock) -> None:
     """Test custom screeners reject the predefined-query count parameter."""
     query = {"operator": "eq", "operands": ["region", "us"]}
 
     result = await screen(query, query_type="equity", count=10)
+    data = json.loads(result)
+
+    assert data["error_code"] == "INVALID_PARAMS"
+    assert data["details"]["invalid_parameter"] == "count"
+    assert data["details"]["expected_parameter"] == "size"
+    mock_to_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("yfmcp.server.asyncio.to_thread")
+async def test_screen_custom_etf_rejects_count_parameter(mock_to_thread: AsyncMock) -> None:
+    """Test custom ETF screeners reject the predefined-query count parameter."""
+    query = {"operator": "eq", "operands": ["categoryname", "Large Blend"]}
+
+    result = await screen(query, query_type="etf", count=10)
     data = json.loads(result)
 
     assert data["error_code"] == "INVALID_PARAMS"


### PR DESCRIPTION
## Summary
- add a unified analyst estimates tool for consensus recommendations, earnings/revenue estimates, EPS trends and revisions, earnings history, and growth estimates
- add ETF and mutual-fund look-through data for operations, exposures, holdings, characteristics, ratings, and sector weights
- add `ETFQuery` support to the existing custom screener
- document the interfaces, row limits, and partial-failure behavior

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check src tests`
- `uv run pytest -v -s --cov=src tests` (142 passed, 84% coverage)
- `uv run --with prek prek run -a`
- live MCP stdio smoke tests for tool discovery, analyst estimates, fund holdings, and ETF screening